### PR TITLE
eth_getBlockTransactionCountByNumber add check block undefined

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -173,7 +173,11 @@ GethApiDouble.prototype.eth_getBlockByHash = function(tx_hash, include_full_tran
 
 GethApiDouble.prototype.eth_getBlockTransactionCountByNumber = function(block_number, callback) {
   this.state.blockchain.getBlock(block_number, function(err, block) {
-    callback(null, block.transactions.length);
+    if (block) {
+      callback(null, block.transactions.length);
+    } else {
+      callback(null, 0);
+    }
   });
 }
 


### PR DESCRIPTION
eth_getBlockTransactionCountByNumber method should check the block for undefined station, when somebody call `web3.eth.getBlockTransactionCount` from geth or truffle console directly will always get the testrpc crash.
And maybe other method also need some security check, and I will help checkout them if you give me this pleasure, tks.