### PR TITLE
Fix broken tests - update findPath reference from merkle-patricia-tree

### DIFF
--- a/lib/utils/forkedstoragetrie.js
+++ b/lib/utils/forkedstoragetrie.js
@@ -27,7 +27,7 @@ function ForkedStorageTrie(db, root, options) {
 ForkedStorageTrie.prototype.keyExists = function(key, callback) {
   key = utils.toBuffer(key);
 
-  this._findPath(key, function (err, node, remainder, stack) {
+  this.findPath(key, function (err, node, remainder, stack) {
     var exists = false;
     if (node && remainder.length === 0) {
       exists = true;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "level-sublevel": "^6.6.1",
     "levelup": "^1.1.0",
     "localstorage-down": "^0.6.7",
-    "merkle-patricia-tree": "^2.1.2",
+    "merkle-patricia-tree": "^2.2.0",
     "mocha": "~2.2.5",
     "on-build-webpack": "^0.1.0",
     "prepend-file": "^1.3.1",


### PR DESCRIPTION
After installing a fresh version of `ganache-core`,  the tests are failing with:

```
Uncaught TypeError: this._findPath is not a function
```

This is due to referencing an outdated method `_findPath` of `merkle-patricia-tree` library which has been recently made public in version `2.2.0` after [this commit](https://github.com/ethereumjs/merkle-patricia-tree/commit/7dd1fd54cfb41c1a13fd99b10c68fbca39342347).

The dependency to `merkle-patricia-tree` was set to look for anything above `2.1.2` thats why it took an updated version in a fresh built. 

I'm updating both the referenced method and increasing dependency so it won't use old cached version. 