### PR TITLE
Support alternate DB providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"locked"`: `boolean` - whether or not accounts are locked by default.
 * `"unlocked_accounts"`: `Array` - array of addresses or address indexes specifying which accounts should be unlocked.
 * `"db_path"`: `String` - Specify a path to a directory to save the chain database. If a database already exists, that chain will be initialized instead of creating a new one.
+* `"db"`: `Object` - Specify an alternative database instance, for instance [MemDOWN](https://github.com/level/memdown).
 
 # IMPLEMENTED METHODS
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -36,6 +36,8 @@ Database.prototype.initialize = function(callback) {
     levelup(directory, {
       valueEncoding: "json",
       db: function (location) {
+        if (self.options.db) return self.options.db;
+
         // This cache size was chosen from a plethora of hand testing.
         // It seems a not-too-large cache (100) size is the right amount.
         // When higher (say 10000), it seems the benefits wear off.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "webpack": "^2.2.1",
     "yargs": "^7.0.2"
   },
+  "devDependencies": {
+    "memdown": "^1.3.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufflesuite/ganache-core"

--- a/test/custom_db.js
+++ b/test/custom_db.js
@@ -1,0 +1,102 @@
+var assert = require('assert');
+var memdown = require('memdown');
+var Web3 = require('web3');
+var TestRPC = require("../index.js");
+
+describe("DB can be customized", function() {
+  describe("Persistence", function() {
+    var db = memdown();
+    var web3 = new Web3();
+    var provider;
+    var accounts;
+    var tx_hash;
+
+    // initialize a memory-persistent provider
+    before('init provider', function (done) {
+      provider = TestRPC.provider({
+        db,
+        mnemonic: "debris electric learn dove warrior grow pistol carry either curve radio hidden"
+      });
+      web3.setProvider(provider);
+      done();
+    });
+
+    before("Gather accounts", function(done) {
+      web3.eth.getAccounts(function(err, a) {
+        if (err) return done(err);
+        accounts = a;
+        done();
+      });
+    });
+
+    before("send transaction", function (done) {
+      web3.eth.sendTransaction({
+        from: accounts[0],
+        gas: '0x2fefd8',
+        data: contract.binary
+      }, function(err, hash) {
+        if (err) return done(err);
+        tx_hash = hash;
+        done();
+      });
+    });
+
+    it("should have block height 1", function (done) {
+      this.timeout(5000);
+      web3.eth.getBlockNumber(function(err, res) {
+        if (err) return done(err);
+
+        assert(res == 1);
+
+        // Close the first provider now that we've gotten where we need to be.
+        // Note: we specifically close the provider so we can read from the same db.
+        provider.close(done);
+      });
+    });
+
+    it("should reopen the provider", function (done) {
+      provider = TestRPC.provider({
+        db,
+        mnemonic: "debris electric learn dove warrior grow pistol carry either curve radio hidden"
+        // logger: console,
+        // verbose: true
+      });
+      web3.setProvider(provider);
+      done();
+    });
+
+    it("should still be on block height 1", function (done) {
+      this.timeout(5000);
+      web3.eth.getBlockNumber(function(err, result) {
+        if (err) return done(err);
+        assert(result == 1);
+        done();
+      });
+    });
+
+    it("should still have block data for first block", function (done) {
+      web3.eth.getBlock(1, function(err, result) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it("should have a receipt for the previous transaction", function(done) {
+      web3.eth.getTransactionReceipt(tx_hash, function(err, receipt) {
+        if (err) return done(err);
+
+        assert.notEqual(receipt, null, "Receipt shouldn't be null!");
+        assert.equal(receipt.transactionHash, tx_hash);
+        done();
+      })
+    });
+
+    it("should maintain the balance of the original accounts", function (done) {
+      web3.eth.getBalance(accounts[0], function(err, balance) {
+        if (err) return done(err);
+        assert(balance.toNumber() > 98);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #5 by allowing a LevelDOWN compatible instance to be provided through the 'db' option.

Tests are copied from `test/persistence.js`, which seemed appropriate.

This fork is being used internally so unfortunately I can't allow edits from maintainers on this PR.