### PR TITLE
Continue with Geth API requests immediately after initialization

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -19,21 +19,31 @@ function GethApiDouble(options) {
   this.initialized = false;
 
   this.initialization_error = null;
+  this.post_initialization_callbacks = [];
 
   this.state.initialize(this.options, function(err) {
     if (err) {
       self.initialization_error = err;
     }
     self.initialized = true;
+
+    var callbacks = self.post_initialization_callbacks;
+    self.post_initialization_callbacks = [];
+
+    setImmediate(function() {
+      callbacks.forEach(function(callback) {
+        callback();
+      });
+    });
   });
 }
 
 GethApiDouble.prototype.waitForInitialization = function(callback) {
   var self = this;
   if (this.initialized == false) {
-    setTimeout(function() {
+    this.post_initialization_callbacks.push(function() {
       self.waitForInitialization(callback);
-    }, 100);
+    });
   } else {
     callback(this.initialization_error, this.state);
   }
@@ -48,7 +58,7 @@ GethApiDouble.prototype.handleRequest = function(payload, next, end) {
   }
 
   if (this.initialized == false) {
-    setTimeout(this.getDelayedHandler(payload, next, end), 100);
+    this.post_initialization_callbacks.push(this.getDelayedHandler(payload, next, end));
     return;
   }
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -30,8 +30,8 @@ function GethApiDouble(options) {
     var callbacks = self.post_initialization_callbacks;
     self.post_initialization_callbacks = [];
 
-    setImmediate(function() {
-      callbacks.forEach(function(callback) {
+    callbacks.forEach(function(callback) {
+      setImmediate(function() {
         callback();
       });
     });


### PR DESCRIPTION
Rather than repeatedly waiting for 100ms until the state is initialized,
continue API requests immediately by tracking callbacks and running them
directly.

This fork is being used internally so unfortunately I can't allow edits from maintainers on this PR.
