### PR TITLE
upgrade ethereumjs-vm to 2.3.1 (Byzantium)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ethereumjs-block": "~1.2.2",
     "ethereumjs-tx": "^1.3.0",
     "ethereumjs-util": "~5.1.0",
-    "ethereumjs-vm": "~2.2.0",
+    "ethereumjs-vm": "2.3.1",
     "ethereumjs-wallet": "~0.6.0",
     "fake-merkle-patricia-tree": "~1.0.1",
     "heap": "~0.2.6",


### PR DESCRIPTION
This PR upgrades ganache-core to be compatible with the Byzantium release.