### PR TITLE
update to solc 0.4.18, fix broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepend-file": "^1.3.1",
     "seedrandom": "~2.4.2",
     "shebang-loader": "0.0.1",
-    "solc": "0.4.8",
+    "solc": "0.4.18",
     "temp": "^0.8.3",
     "tmp": "0.0.31",
     "web3": "^0.19.1",

--- a/test/block_tags.js
+++ b/test/block_tags.js
@@ -23,8 +23,8 @@ var result = solc.compile(source, 1);
 // make sure to update the resulting contract data with the correct values.
 var contract = {
   solidity: source,
-  abi: result.contracts.Example.interface,
-  binary: "0x" + result.contracts.Example.bytecode,
+  abi: result.contracts[":Example"].interface,
+  binary: "0x" + result.contracts[":Example"].bytecode,
   position_of_value: "0x0000000000000000000000000000000000000000000000000000000000000000",
   expected_default_value: 5,
   call_data: {

--- a/test/debug.js
+++ b/test/debug.js
@@ -36,8 +36,8 @@ describe("Debug", function() {
     this.timeout(10000);
     var result = solc.compile({sources: {"DebugContract.sol": source}}, 1);
 
-    var code = "0x" + result.contracts.DebugContract.bytecode;
-    var abi = JSON.parse(result.contracts.DebugContract.interface);
+    var code = "0x" + result.contracts["DebugContract.sol:DebugContract"].bytecode;
+    var abi = JSON.parse(result.contracts["DebugContract.sol:DebugContract"].interface);
 
     DebugContract = web3.eth.contract(abi);
     DebugContract._code = code;
@@ -107,7 +107,7 @@ describe("Debug", function() {
 
       assert.equal(lastop.op, "STOP");
       assert.equal(lastop.gasCost, 1);
-      assert.equal(lastop.pc, 86);
+      assert.equal(lastop.pc, 131);
 
       // Now let's make sure rerunning this transaction trace didn't change state
       debugContract.value({from: accounts[0], gas: 3141592}, function(err, value) {

--- a/test/events.js
+++ b/test/events.js
@@ -9,7 +9,7 @@ pragma solidity ^0.4.2;             \
 contract EventTest {                \
   event ExampleEvent(uint indexed first, uint indexed second);   \
                                     \
-  function triggerEvent(uint _first, uint _second) { \
+  function triggerEvent(uint _first, uint _second) public { \
     ExampleEvent(_first, _second);      \
   }                                 \
 }"
@@ -39,9 +39,9 @@ var tests = function(web3, EventTest) {
         throw new Error(result.errors[0]);
       }
 
-      var abi = JSON.parse(result.contracts.EventTest.interface);
+      var abi = JSON.parse(result.contracts[":EventTest"].interface);
       EventTest = web3.eth.contract(abi);
-      EventTest._data = "0x" + result.contracts.EventTest.bytecode;
+      EventTest._data = "0x" + result.contracts[":EventTest"].bytecode;
     });
 
     before(function(done) {

--- a/test/forking.js
+++ b/test/forking.js
@@ -50,8 +50,8 @@ describe("Forking", function() {
     // make sure to update the resulting contract data with the correct values.
     contract = {
       solidity: source,
-      abi: result.contracts.Example.interface,
-      binary: "0x" + result.contracts.Example.bytecode,
+      abi: result.contracts[":Example"].interface,
+      binary: "0x" + result.contracts[":Example"].bytecode,
       position_of_value: "0x0000000000000000000000000000000000000000000000000000000000000000",
       expected_default_value: 5,
       call_data: {
@@ -384,7 +384,8 @@ describe("Forking", function() {
   // Note: This test also puts a new contract on the forked chain, which is a good test.
   it("should represent the block number correctly in the Oracle contract (oracle.blockhash0), providing forked block hash and number", function(done){
     var oracleSol = fs.readFileSync("./test/Oracle.sol", {encoding: "utf8"});
-    var oracleOutput = solc.compile(oracleSol).contracts.Oracle;
+    var solcResult = solc.compile(oracleSol);
+    var oracleOutput = solcResult.contracts[":Oracle"];
 
     mainWeb3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: mainAccounts[0], gas: 3141592 }, function(err, oracle){
       if(err) return done(err)

--- a/test/forkingasprovider.js
+++ b/test/forkingasprovider.js
@@ -46,8 +46,8 @@ describe("Forking using a Provider", function() {
     // make sure to update the resulting contract data with the correct values.
     contract = {
       solidity: source,
-      abi: result.contracts.Example.interface,
-      binary: "0x" + result.contracts.Example.bytecode,
+      abi: result.contracts[":Example"].interface,
+      binary: "0x" + result.contracts[":Example"].bytecode,
       position_of_value: "0x0000000000000000000000000000000000000000000000000000000000000000",
       expected_default_value: 5,
       call_data: {

--- a/test/gas.js
+++ b/test/gas.js
@@ -28,8 +28,8 @@ describe("Gas Estimation", function() {
     this.timeout(10000);
     var result = solc.compile({sources: {"EstimateGas.sol": source}}, 1);
 
-    var code = "0x" + result.contracts.EstimateGas.bytecode;
-    var abi = JSON.parse(result.contracts.EstimateGas.interface);
+    var code = "0x" + result.contracts["EstimateGas.sol:EstimateGas"].bytecode;
+    var abi = JSON.parse(result.contracts["EstimateGas.sol:EstimateGas"].interface);
 
     EstimateGasContract = web3.eth.contract(abi);
     EstimateGasContract._code = code;

--- a/test/interval_mining.js
+++ b/test/interval_mining.js
@@ -157,7 +157,7 @@ describe("Interval Mining", function() {
     }));
 
     var result = solc.compile({sources: {"Example.sol": "pragma solidity ^0.4.2; contract Example { function Example() {throw;} }"}}, 1);
-    var bytecode = "0x" + result.contracts.Example.bytecode;
+    var bytecode = "0x" + result.contracts["Example.sol:Example"].bytecode;
 
     web3.eth.sendTransaction({
       from: first_address,
@@ -168,7 +168,7 @@ describe("Interval Mining", function() {
 
       // Wait .75 seconds (one and a half mining intervals) and ensure log sees error.
       setTimeout(function() {
-        assert(logData.indexOf("Runtime Error: invalid JUMP") >= 0);
+        assert(logData.indexOf("Runtime Error: revert") >= 0);
         done();
       }, 750);
     });

--- a/test/persistence.js
+++ b/test/persistence.js
@@ -17,8 +17,8 @@ var result = solc.compile(source, 1);
 // make sure to update the resulting contract data with the correct values.
 var contract = {
   solidity: source,
-  abi: result.contracts.Example.interface,
-  binary: "0x" + result.contracts.Example.bytecode,
+  abi: result.contracts[":Example"].interface,
+  binary: "0x" + result.contracts[":Example"].bytecode,
   position_of_value: "0x0000000000000000000000000000000000000000000000000000000000000000",
   expected_default_value: 5,
   call_data: {

--- a/test/requests.js
+++ b/test/requests.js
@@ -33,9 +33,9 @@ process.removeAllListeners("uncaughtException");
 // make sure to update the resulting contract data with the correct values.
 var contract = {
   solidity: source,
-  abi: result.contracts.Example.interface,
-  binary: "0x" + result.contracts.Example.bytecode,
-  runtimeBinary: '0x' + result.contracts.Example.runtimeBytecode,
+  abi: result.contracts[":Example"].interface,
+  binary: "0x" + result.contracts[":Example"].bytecode,
+  runtimeBinary: '0x' + result.contracts[":Example"].runtimeBytecode,
   position_of_value: "0x0000000000000000000000000000000000000000000000000000000000000000",
   expected_default_value: 5,
   call_data: {
@@ -580,7 +580,7 @@ var tests = function(web3) {
 
     it("should represent the block number correctly in the Oracle contract (oracle.blockhash0)", function(done){
       var oracleSol = fs.readFileSync("./test/Oracle.sol", {encoding: "utf8"});
-      var oracleOutput = solc.compile(oracleSol).contracts.Oracle
+      var oracleOutput = solc.compile(oracleSol).contracts[":Oracle"]
       web3.eth.contract(JSON.parse(oracleOutput.interface)).new({ data: oracleOutput.bytecode, from: accounts[0], gas: 3141592 }, function(err, oracle){
         if(err) return done(err)
         if(!oracle.address) return
@@ -610,7 +610,7 @@ var tests = function(web3) {
 
         web3.eth.estimateGas(tx_data, function(err, result) {
           if (err) return done(err);
-          assert.equal(result, 27724);
+          assert.equal(result, 27682);
 
           web3.eth.getBlockNumber(function(err, result) {
             if (err) return done(err);
@@ -631,7 +631,7 @@ var tests = function(web3) {
 
       web3.eth.estimateGas(tx_data, function(err, result) {
         if (err) return done(err);
-        assert.equal(result, 27724);
+        assert.equal(result, 27682);
         done();
       });
     });
@@ -645,7 +645,7 @@ var tests = function(web3) {
 
       web3.eth.estimateGas(tx_data, function(err, result) {
         if (err) return done(err);
-        assert.equal(result, 27724);
+        assert.equal(result, 27682);
         done();
       });
     });

--- a/test/runtime_errors.js
+++ b/test/runtime_errors.js
@@ -31,8 +31,8 @@ describe("Runtime Errors", function() {
     var source = fs.readFileSync(path.join(__dirname, "RuntimeError.sol"), "utf8");
     var result = solc.compile({sources: {"RuntimeError.sol": source}}, 1);
 
-    code = "0x" + result.contracts.RuntimeError.bytecode;
-    var abi = JSON.parse(result.contracts.RuntimeError.interface);
+    code = "0x" + result.contracts["RuntimeError.sol:RuntimeError"].bytecode;
+    var abi = JSON.parse(result.contracts["RuntimeError.sol:RuntimeError"].interface);
 
     ErrorContract = web3.eth.contract(abi);
     ErrorContract._code = code;
@@ -51,7 +51,9 @@ describe("Runtime Errors", function() {
     errorInstance.error({from: accounts[0], gas: 3141592}, function(err) {
       assert(err.hashes.length > 0);
       assert(Object.keys(err.results).length > 0);
-      assert.equal(err.results[err.hashes[0]].program_counter, 44); // magic number, will change if compiler changes.
+
+      //TODO: replace this w/ an address lookup, or a precompiled contract
+      assert.equal(err.results[err.hashes[0]].program_counter, 77); // magic number, will change if compiler changes.
       done();
     });
   });


### PR DESCRIPTION
This is needed in order to properly validate changes from the Byzantium hard fork. Required test maintenance mostly due to a breaking change in the way compiled contracts are referenced in the compiler's return object.