### PR TITLE
Byzantium add txreceipt status rebased

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -545,7 +545,7 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
         }
       }
 
-      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress));
+      receipts.push(new Receipt(tx, block, tx_logs, receipt.gasUsed, result.createdAddress, receipt.status));
     }
 
     function commmitIfNeeded(cb) {

--- a/lib/database/receiptserializer.js
+++ b/lib/database/receiptserializer.js
@@ -25,7 +25,7 @@ ReceiptSerializer.prototype.decode = function(json, done) {
       }, function(err, result) {
         if (err) return done(err);
 
-        done(null, new Receipt(tx, result.block, result.logs, json.gasUsed, json.contractAddress));
+        done(null, new Receipt(tx, result.block, result.logs, json.gasUsed, json.contractAddress, json.status));
       });
     });
   });

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -392,7 +392,7 @@ ForkedBlockchain.prototype.getTransactionReceipt = function(hash, callback) {
           return new Log(log);
         });
 
-        var receipt = new Receipt(result.tx, result.block, logs, receipt_json.cumulativeGasUsed, receipt_json.contractAddress);
+        var receipt = new Receipt(result.tx, result.block, logs, receipt_json.cumulativeGasUsed, receipt_json.contractAddress, receipt_json.status);
 
         callback(null, receipt);
       });

--- a/lib/utils/receipt.js
+++ b/lib/utils/receipt.js
@@ -1,11 +1,12 @@
 var to = require("./to");
 
-function Receipt(tx, block, logs, gasUsed, contractAddress) {
+function Receipt(tx, block, logs, gasUsed, contractAddress, status) {
   this.tx = tx;
   this.block = block;
   this.logs = logs;
   this.gasUsed = gasUsed;
   this.contractAddress = contractAddress;
+  this.status = status;
 
   this.transactionIndex = 0;
 
@@ -29,7 +30,8 @@ Receipt.prototype.toJSON = function() {
     gasUsed: to.hex(this.gasUsed),
     cumulativeGasUsed: to.hex(this.block.header.gasUsed),
     contractAddress: this.contractAddress != null ? to.hex(this.contractAddress) : null,
-    logs: this.logs.map(function(log) {return log.toJSON()})
+    logs: this.logs.map(function(log) {return log.toJSON()}),
+    status: to.number(this.status)
   }
 };
 

--- a/test/Revert.sol
+++ b/test/Revert.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.18;
+
+contract Revert {
+  uint public value;
+
+  event ValueSet(uint);
+
+  function alwaysReverts(uint val) public {
+    value = val;
+    ValueSet(val);
+    revert();
+  }
+}

--- a/test/vm.js
+++ b/test/vm.js
@@ -25,32 +25,33 @@ web3.setProvider(TestRPC.provider({
   seed: "1337"
 }));
 
-var testContext = {};
+describe("revert opcode", function() {
+  var testContext = {};
 
-before(function (done) {
-  testContext.source = fs.readFileSync("./test/Revert.sol", {encoding: "utf8"});
-  testContext.solcResult = solc.compile(testContext.source, false);
+  before(function (done) {
+    this.timeout(10000);
+    testContext.source = fs.readFileSync("./test/Revert.sol", {encoding: "utf8"});
+    testContext.solcResult = solc.compile(testContext.source, false);
 
-  testContext.revertContract = {
-    solidity: testContext.source,
-    abi: testContext.solcResult.contracts[":Revert"].interface,
-    binary: "0x" + testContext.solcResult.contracts[":Revert"].bytecode,
-    runtimeBinary: '0x' + testContext.solcResult.contracts[":Revert"].runtimeBytecode
-  };
+    testContext.revertContract = {
+      solidity: testContext.source,
+      abi: testContext.solcResult.contracts[":Revert"].interface,
+      binary: "0x" + testContext.solcResult.contracts[":Revert"].bytecode,
+      runtimeBinary: '0x' + testContext.solcResult.contracts[":Revert"].runtimeBytecode
+    };
 
-  web3.eth.getAccounts(function(err, accs) {
-    if (err) return done(err);
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
 
-    testContext.accounts = accs;
+      testContext.accounts = accs;
 
-    web3.personal.newAccount("password", function(err, result) {
-      testContext.personalAccount = result;
-      done();
+      web3.personal.newAccount("password", function(err, result) {
+        testContext.personalAccount = result;
+        done();
+      });
     });
   });
-});
 
-describe("revert opcode", function() {
   it("should return a transaction receipt with status 0 on REVERT", function(done) {
     var revertCode = testContext.revertContract.binary;
     var revertAbi = JSON.parse(testContext.revertContract.abi);

--- a/test/vm.js
+++ b/test/vm.js
@@ -74,7 +74,7 @@ describe("revert opcode", function() {
             }
 
             assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");
-            assert.equal(receipt.status, 0, "Reverted transactions should have a status of 0.");
+            assert.equal(receipt.status, 0, "Reverted (failed) transactions should have a status of 0.");
             done();
           });
         });
@@ -88,6 +88,7 @@ describe("revert opcode", function() {
 
           assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");
           assert.notEqual(receipt.contractAddress, null, "Transaction did not create a contract");
+            assert.equal(receipt.status, 1, "Successful transactions should have a status of 1.");
           testCall(RevertContract.at(receipt.contractAddress));
         });
       } else {

--- a/test/vm.js
+++ b/test/vm.js
@@ -70,7 +70,7 @@ describe("revert opcode", function() {
 
           web3.eth.getTransactionReceipt(txHash, function(err, receipt) {
             if (err) {
-              done(err);
+              return done(err);
             }
 
             assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");

--- a/test/vm.js
+++ b/test/vm.js
@@ -1,0 +1,98 @@
+var Web3 = require('web3');
+var Transaction = require('ethereumjs-tx');
+var utils = require('ethereumjs-util');
+var assert = require('assert');
+var TestRPC = require("../index.js");
+var solc = require("solc");
+var fs = require("fs");
+var to = require("../lib/utils/to");
+var clone = require("clone");
+
+// Thanks solc. At least this works!
+// This removes solc's overzealous uncaughtException event handler.
+process.removeAllListeners("uncaughtException");
+
+var logger = {
+  log: function(message) {
+    //console.log(message);
+  }
+};
+
+var web3 = new Web3();
+web3.setProvider(TestRPC.provider({
+  /*blocktime: 100,*/
+  logger: logger,
+  seed: "1337"
+}));
+
+var testContext = {};
+
+before(function (done) {
+  testContext.source = fs.readFileSync("./test/Revert.sol", {encoding: "utf8"});
+  testContext.solcResult = solc.compile(testContext.source, false);
+
+  testContext.revertContract = {
+    solidity: testContext.source,
+    abi: testContext.solcResult.contracts[":Revert"].interface,
+    binary: "0x" + testContext.solcResult.contracts[":Revert"].bytecode,
+    runtimeBinary: '0x' + testContext.solcResult.contracts[":Revert"].runtimeBytecode
+  };
+
+  web3.eth.getAccounts(function(err, accs) {
+    if (err) return done(err);
+
+    testContext.accounts = accs;
+
+    web3.personal.newAccount("password", function(err, result) {
+      testContext.personalAccount = result;
+      done();
+    });
+  });
+});
+
+describe("revert opcode", function() {
+  it("should return a transaction receipt with status 0 on REVERT", function(done) {
+    var revertCode = testContext.revertContract.binary;
+    var revertAbi = JSON.parse(testContext.revertContract.abi);
+
+    var RevertContract = web3.eth.contract(revertAbi);
+    RevertContract._code = revertCode;
+    RevertContract.new({ data: revertCode, from: testContext.accounts[0], gas: 3141592 }, function (err, instance) {
+      if (err) {
+        return done(err);
+      }
+
+      var testCall = function(instance) {
+        instance.alwaysReverts(5, { from: testContext.accounts[0] }, function(err, result) {
+          assert(err, "Expected error result not returned.");
+          var txHash = err.hashes[0];
+
+          web3.eth.getTransactionReceipt(txHash, function(err, receipt) {
+            if (err) {
+              done(err);
+            }
+
+            assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");
+            assert.equal(receipt.status, 0, "Reverted transactions should have a status of 0.");
+            done();
+          });
+        });
+      }
+
+      if (!instance.address) {
+        web3.eth.getTransactionReceipt(instance.transactionHash, function(err, receipt) {
+          if (err) {
+            return done(err);
+          }
+
+          assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");
+          assert.notEqual(receipt.contractAddress, null, "Transaction did not create a contract");
+          testCall(RevertContract.at(receipt.contractAddress));
+        });
+      } else {
+        testCall(instance);
+      }
+
+    });
+  });
+});


### PR DESCRIPTION
As of Byzantium, transaction receipts should have a status field which have a value of 1 for success, and 0 for failure.

https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt

Rebased version of #23 