### PR TITLE
Ensured gasPrice can be set to 0

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -61,7 +61,7 @@ StateManager = function(options) {
 
   this.gasPriceVal = '0x4A817C800'; // 0.02 szabo
 
-  if (options.gasPrice) {
+  if (options.gasPrice != null) {
     this.gasPriceVal = utils.stripHexPrefix(utils.intToHex(options.gasPrice));
   }
 


### PR DESCRIPTION
It should be possible to set the `gasPrice` to ` 0` if desired but the current implementation doesn't allow it. This commit fixes this behaviour.