### PR TITLE
Fix getTransactionCount leading zeros in hex string

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -13,7 +13,6 @@ var async = require("async");
 var BlockchainDouble = require("./blockchain_double.js");
 var ForkedBlockchain = require("./utils/forkedblockchain.js");
 var Web3 = require('web3');
-var async = require("async");
 var util = require("util");
 
 var to = require('./utils/to');
@@ -210,7 +209,7 @@ StateManager.prototype.getBalance = function(address, number, callback) {
 StateManager.prototype.getTransactionCount = function(address, number, callback) {
   this.blockchain.getNonce(address, number, function(err, nonce) {
     if (nonce) {
-      nonce = to.hex(nonce);
+      nonce = to.hexWithoutLeadingZeroes(nonce);
     }
     callback(err, nonce);
   });

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -30,7 +30,13 @@ module.exports = {
 
   hexWithoutLeadingZeroes: function(val) {
     val = this.hex(val);
-    return "0x" + val.replace("0x", "").replace(/^0+/, "");
+    val = "0x" + val.replace("0x", "").replace(/^0+/, "");
+
+    if (val == "0x") {
+      val = "0x0";
+    }
+
+    return val;
   },
 
   number: function(val) {

--- a/test/hex.js
+++ b/test/hex.js
@@ -1,0 +1,108 @@
+var assert = require("assert");
+var Web3 = require("web3");
+var TestRPC = require("../index.js");
+var to = require("../lib/utils/to.js");
+
+describe("to.hexWithoutLeadingZeroes", function() {
+  it("should print '0x0' for input 0", function(done) {
+    assert.equal(to.hexWithoutLeadingZeroes(0), "0x0");
+    done();
+  });
+
+  it("should print '0x0' for input '0'", function(done) {
+    assert.equal(to.hexWithoutLeadingZeroes("0"), "0x0");
+    done();
+  });
+
+  it("should print '0x0' for input '000'", function(done) {
+    assert.equal(to.hexWithoutLeadingZeroes("000"), "0x0");
+    done();
+  });
+
+  it("should print '0x0' for input '0x000'", function(done) {
+    assert.equal(to.hexWithoutLeadingZeroes("0x000"), "0x0");
+    done();
+  });
+
+  it("should print '0x20' for input '0x0020'", function(done) {
+    assert.equal(to.hexWithoutLeadingZeroes("0x0020"), "0x20");
+    done();
+  });
+});
+
+function noLeadingZeros(result) {
+  if (typeof result === "string") {
+    if (/^0x/.test(result)) {
+      assert.equal(result, to.hexWithoutLeadingZeroes(result));
+    }
+  } else if (typeof result === "object") {
+    for (var key in result) {
+      if (result.hasOwnProperty(key)) {
+        noLeadingZeros(result[key]);
+      }
+    }
+  }
+}
+
+describe("JSON-RPC Response", function() {
+  var web3 = new Web3();
+  var provider = TestRPC.provider();
+  web3.setProvider(provider);
+
+  var accounts;
+  before(function(done) {
+    web3.eth.getAccounts(function(err, accs) {
+      if (err) return done(err);
+      accounts = accs;
+      done();
+    });
+  });
+
+  it("should not have leading zeros in hex strings", function(done) {
+    var request = {
+      "jsonrpc": "2.0",
+      "method": "eth_getTransactionCount",
+      "params": [
+        accounts[0],
+        "pending"
+      ],
+      "id": 1
+    };
+
+    provider.sendAsync(request, function(err, result) {
+      noLeadingZeros(result);
+
+      request = {
+        "jsonrpc": "2.0",
+        "method": "eth_sendTransaction",
+        "params": [
+          {
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": "0x100000000"
+          }
+        ],
+        "id": 2
+      };
+
+      provider.sendAsync(request, function(err, result) {
+        noLeadingZeros(result);
+
+        request = {
+          "jsonrpc": "2.0",
+          "method": "eth_getTransactionCount",
+          "params": [
+            accounts[0],
+            "pending"
+          ],
+          "id": 3
+        };
+
+        provider.sendAsync(request, function(err, result) {
+          noLeadingZeros(result);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
As described [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding) (emphasis mine):

> When encoding QUANTITIES (integers, numbers): encode as hex, prefix with "0x", the **most compact representation** (slight exception: zero should be represented as "0x0").

The implementation of `getTransactionCount` would encode numbers including a leading zero, for example: `4` would become `0x04` instead of the correct way `0x4`.

This PR fixes it, and also fixes the function `hexWithoutLeadingZeroes` in `lib/utils/to.js` to correctly convert `0` to `0x0` instead of `0x` (which would lead to an exception in [Web3js when creating a BigNumber](https://github.com/ethereum/web3.js/blob/306680f8d917f912d9c6ed632d133274909cee87/lib/utils/utils.js#L356-L367), more specifically at line 363).

I tried to add a test for this change, but as Web3 already returns the decoded number, I wasn't able to find the right place to check that the hex string is returned correctly.

Related issues and PRs that might related to this PR:
* Fixes https://github.com/ethereumjs/testrpc/issues/220;
* Relates to https://github.com/web3j/web3j/pull/23, probably allowing to revert it;
* Similar to https://github.com/ethereumjs/ethereumjs-tx/issues/51