### PR TITLE
Fixed logging bug

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -440,7 +440,7 @@ StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callba
 
       self.logger.log("  Gas usage: " + parseInt(receipt.gasUsed, 16));
       self.logger.log("  Block Number: " + parseInt(receipt.blockNumber, 16));
-      self.logger.log("  Block Time: " + new Date(to.number(block.header.timestamp) * 1000).toString());
+      self.logger.log("  Block Time: " + new Date(block.header.timestamp * 1000).toString());
 
       if (error) {
         self.logger.log("  Runtime Error: " + error.error);


### PR DESCRIPTION
Updating block time triggered caused "only 53 bits of precision" error. Discovered when issuing evm_increaseTime RPC. Apparently block timestamps are already numbers.