### PR TITLE
strip leading zeroes for eth_getBalance()

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -208,7 +208,7 @@ StateManager.prototype.gasPrice = function() {
 StateManager.prototype.getBalance = function(address, number, callback) {
   this.blockchain.getBalance(address, number, function(err, balance) {
     if (balance) {
-      balance = to.hex(balance);
+      balance = to.rpcQuantityHexString(balance);
     }
     callback(err, balance);
   });
@@ -217,7 +217,7 @@ StateManager.prototype.getBalance = function(address, number, callback) {
 StateManager.prototype.getTransactionCount = function(address, number, callback) {
   this.blockchain.getNonce(address, number, function(err, nonce) {
     if (nonce) {
-      nonce = to.hexWithoutLeadingZeroes(nonce);
+      nonce = to.rpcQuantityHexString(nonce);
     }
     callback(err, nonce);
   });

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -148,10 +148,11 @@ GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_fu
     }
 
     callback(null, {
-      number: to.hex(block.header.number),
+      number: to.rpcQuantityHexString(block.header.number),
       hash: to.hex(block.hash()),
-      parentHash: to.hex(block.header.parentHash),
-      nonce: to.hex(block.header.nonce),
+      parentHash: to.hex(block.header.parentHash), //common.hash
+      mixHash: "0x" + (new Array(32).fill("10").join("")), // TODO: Figure out what to do here.
+      nonce: to.rpcDataHexString(to.hex(block.header.nonce), 16),
       sha3Uncles: to.hex(block.header.uncleHash),
       logsBloom: to.hex(block.header.bloom),
       transactionsRoot: to.hex(block.header.transactionsTrie),
@@ -160,7 +161,7 @@ GethApiDouble.prototype.eth_getBlockByNumber = function(block_number, include_fu
       miner: to.hex(block.header.coinbase),
       difficulty: to.hex(block.header.difficulty),
       totalDifficulty: to.hex(block.header.difficulty), // TODO: Figure out what to do here.
-      extraData: to.hex(block.header.extraData),
+      extraData: to.rpcDataHexString(to.hex(block.header.extraData)),
       size: to.hex(1000), // TODO: Do something better here
       gasLimit: to.hex(block.header.gasLimit),
       gasUsed: to.hex(block.header.gasUsed),

--- a/lib/utils/forkedstoragetrie.js
+++ b/lib/utils/forkedstoragetrie.js
@@ -47,7 +47,7 @@ ForkedStorageTrie.prototype.get = function(key, block_number, callback) {
   }
 
   // For geth; https://github.com/ethereumjs/ethereumjs-util/issues/79
-  block_number = to.hexWithoutLeadingZeroes(block_number);
+  block_number = to.rpcQuantityHexString(block_number);
 
   key = utils.toBuffer(key);
 

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -28,7 +28,7 @@ module.exports = {
     return utils.addHexPrefix(val);
   },
 
-  hexWithoutLeadingZeroes: function(val) {
+  rpcQuantityHexString: function(val) {
     val = this.hex(val);
     val = "0x" + val.replace("0x", "").replace(/^0+/, "");
 
@@ -37,6 +37,21 @@ module.exports = {
     }
 
     return val;
+  },
+
+  rpcDataHexString: function(val, length) {
+    if(typeof(length) == "number") {
+      val = this.hex(val).replace("0x", "");
+
+      val = new Array(length-val.length).fill("0").join("") + val;
+    } else {
+      val = this.hex(val).replace("0x", "");
+
+      if(val.length % 2 != 0) {
+        val = "0" + val;
+      }
+    }
+    return "0x" + val;
   },
 
   number: function(val) {

--- a/test/hex.js
+++ b/test/hex.js
@@ -3,29 +3,29 @@ var Web3 = require("web3");
 var TestRPC = require("../index.js");
 var to = require("../lib/utils/to.js");
 
-describe("to.hexWithoutLeadingZeroes", function() {
+describe("to.rpcQuantityHexString", function() {
   it("should print '0x0' for input 0", function(done) {
-    assert.equal(to.hexWithoutLeadingZeroes(0), "0x0");
+    assert.equal(to.rpcQuantityHexString(0), "0x0");
     done();
   });
 
   it("should print '0x0' for input '0'", function(done) {
-    assert.equal(to.hexWithoutLeadingZeroes("0"), "0x0");
+    assert.equal(to.rpcQuantityHexString("0"), "0x0");
     done();
   });
 
   it("should print '0x0' for input '000'", function(done) {
-    assert.equal(to.hexWithoutLeadingZeroes("000"), "0x0");
+    assert.equal(to.rpcQuantityHexString("000"), "0x0");
     done();
   });
 
   it("should print '0x0' for input '0x000'", function(done) {
-    assert.equal(to.hexWithoutLeadingZeroes("0x000"), "0x0");
+    assert.equal(to.rpcQuantityHexString("0x000"), "0x0");
     done();
   });
 
   it("should print '0x20' for input '0x0020'", function(done) {
-    assert.equal(to.hexWithoutLeadingZeroes("0x0020"), "0x20");
+    assert.equal(to.rpcQuantityHexString("0x0020"), "0x20");
     done();
   });
 });
@@ -33,7 +33,7 @@ describe("to.hexWithoutLeadingZeroes", function() {
 function noLeadingZeros(result) {
   if (typeof result === "string") {
     if (/^0x/.test(result)) {
-      assert.equal(result, to.hexWithoutLeadingZeroes(result));
+      assert.equal(result, to.rpcQuantityHexString(result));
     }
   } else if (typeof result === "object") {
     for (var key in result) {

--- a/test/requests.js
+++ b/test/requests.js
@@ -160,8 +160,9 @@ var tests = function(web3) {
         var expectedFirstBlock = {
           number: 0,
           hash: block.hash, // Don't test this one
+          mixHash: "0x1010101010101010101010101010101010101010101010101010101010101010",
           parentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
-          nonce: '0x0',
+          nonce: '0x0000000000000000',
           sha3Uncles: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
           logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
           transactionsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
@@ -170,7 +171,7 @@ var tests = function(web3) {
           miner: '0x0000000000000000000000000000000000000000',
           difficulty: { s: 1, e: 0, c: [ 0 ] },
           totalDifficulty: { s: 1, e: 0, c: [ 0 ] },
-          extraData: '0x0',
+          extraData: '0x00',
           size: 1000,
           gasLimit: 6721975,
           gasUsed: 0,
@@ -336,22 +337,22 @@ var tests = function(web3) {
     });
 
     it("should produce a signature whose signer can be recovered", function(done) {
-  	  var msg = utils.toBuffer("asparagus");
+      var msg = utils.toBuffer("asparagus");
       var msgHash = utils.hashPersonalMessage(msg);
-  	  web3.eth.sign(accounts[0], utils.bufferToHex(msg), function(err, sgn) {
+      web3.eth.sign(accounts[0], utils.bufferToHex(msg), function(err, sgn) {
         if (err) return done(err);
 
-    	  sgn = utils.stripHexPrefix(sgn);
-    		var r = new Buffer(sgn.slice(0, 64), 'hex');
-    		var s = new Buffer(sgn.slice(64, 128), 'hex');
-    		var v = parseInt(sgn.slice(128, 130), 16) + 27;
-    		var pub = utils.ecrecover(msgHash, v, r, s);
-    		var addr = utils.setLength(utils.fromSigned(utils.pubToAddress(pub)), 20);
-    		addr = utils.addHexPrefix(addr.toString('hex'));
-    		assert.deepEqual(addr, accounts[0]);
-    		done();
-	    });
-  	});
+        sgn = utils.stripHexPrefix(sgn);
+        var r = new Buffer(sgn.slice(0, 64), 'hex');
+        var s = new Buffer(sgn.slice(64, 128), 'hex');
+        var v = parseInt(sgn.slice(128, 130), 16) + 27;
+        var pub = utils.ecrecover(msgHash, v, r, s);
+        var addr = utils.setLength(utils.fromSigned(utils.pubToAddress(pub)), 20);
+        addr = utils.addHexPrefix(addr.toString('hex'));
+        assert.deepEqual(addr, accounts[0]);
+        done();
+      });
+    });
 
     it("should work if ecsign produces 'r' or 's' components that start with 0", function(done){
       // This message produces a zero prefixed 'r' component when signed by ecsign


### PR DESCRIPTION
I got some errors due to formatting of results from ganache preventing it from being used as a drop in replacement for geth. You can reproduce the errors with the following steps.

1.
start ganache
`ganache-cli --deterministic`

2.
and run this go code using the go-ethereum libraries
```go
package main

import (
	"context"
	"log"
	"math/big"

	"github.com/ethereum/go-ethereum/common"
	"github.com/ethereum/go-ethereum/ethclient"
)

func main() {
	const Account = "0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1"

	ethAPI, err := ethclient.Dial("http://localhost:8545")
	if err != nil {
		log.Fatalf("Failed to connect to the Ethereum client: %v", err)
	}

        //result, err := ethAPI.BlockByNumber(context.Background(), big.NewInt(18))
	result, err := ethAPI.BalanceAt(context.Background(), common.HexToAddress(Account), big.NewInt(0))
	if err != nil {
		log.Fatalf("Get Balance failed: %v", err)
	}

	log.Println(result)
}
```
The code here is fix errors for calls to `eth_getBalance` and `eth_getBlockByNumber`