### PR TITLE
Allow newer versions of Solidity 0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"fork"`: `string` or `object` - When a `string`, same as `--fork` option above. Can also be a Web3 Provider object, optionally used in conjunction with the `fork_block_number` option below.
 * `"fork_block_number"`: `string` or `number` - Block number the provider should fork from, when the `fork` option is specified. If the `fork` option is specified as a string including the `@` sign and a block number, the block number in the `fork` parameter takes precedence.
 * `"network_id"`: `integer` - Same as `--networkId` option above.
-* `"time"`: `Date` - Date that the first block should start. Use this feature, along with the `evm_increaseTime` method to test time-dependent code.
+* `"time"`: `Date` - Date that the first block should start. Use this feature with the `evm_increaseTime` method to test time-dependent code.
 * `"locked"`: `boolean` - whether or not accounts are locked by default.
 * `"unlocked_accounts"`: `Array` - array of addresses or address indexes specifying which accounts should be unlocked.
 * `"db_path"`: `String` - Specify a path to a directory to save the chain database. If a database already exists, that chain will be initialized instead of creating a new one.
@@ -118,8 +118,8 @@ The RPC methods currently implemented are:
 There are also special non-standard methods that aren’t included within the original RPC specification:
 
 * `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
-* `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
-* `evm_increaseTime` : Jump forward in time. Takes one parameter, which is the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
+* `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes one parameter: the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.
+* `evm_increaseTime` : Jump forward in time. Takes one parameter: the amount of time to increase in seconds. Returns the total time adjustment, in seconds.
 * `evm_mine` : Force a block to be mined. Takes no parameters. Mines a block independent of whether or not mining is started or stopped.
 
 # Unsupported Methods

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The RPC methods currently implemented are:
 * `web3_clientVersion`
 * `web3_sha3`
 
-There’s also special non-standard methods that aren’t included within the original RPC specification:
+There are also special non-standard methods that aren’t included within the original RPC specification:
 
 * `evm_snapshot` : Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the integer id of the snapshot created.
 * `evm_revert` : Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to. If no snapshot id is passed it will revert to the latest snapshot. Returns `true`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepend-file": "^1.3.1",
     "seedrandom": "~2.4.2",
     "shebang-loader": "0.0.1",
-    "solc": "0.4.18",
+    "solc": "^0.4.18",
     "temp": "^0.8.3",
     "tmp": "0.0.31",
     "web3": "1.0.0-beta.27",


### PR DESCRIPTION
solc should not be restricted to only to version 0.4.18 because [semantic versioning](http://solidity.readthedocs.io/en/develop/layout-of-source-files.html#version-pragma) specifies that only non-breaking changes will be included in the 0.4.x series. Locking it to 0.4.18 means that users of Truffle cannot use Solidity 0.4.19 with its bug fixes, nor 0.4.20 when it comes along, etc.

Did some copyediting on the README to trigger builds, as Travis was being difficult.

See also https://github.com/trufflesuite/truffle/pull/784