### PR TITLE
Cannot read property 'unref' of undefined

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -154,7 +154,7 @@ StateManager.prototype.mineOnInterval = function() {
   }, this.blocktime * 1000);
 
   // Ensure this won't keep a node process open.
-  if (this.mining_interval_timeout.unref) {
+  if (this.mining_interval_timeout && this.mining_interval_timeout.unref) {
     this.mining_interval_timeout.unref();
   }
 };


### PR DESCRIPTION
Not sure the best way to go about diagnosing this problem. It seems to be a non deterministic error message that gets printed to the console. [Here is a screenshot](https://i.imgur.com/Slf1TSU.png). It doesn't cause any of my tests to fail. It just gets printed to the console. Sometime it gets printed even when running tests that do not involve ganache.

(1) Occurs non deterministically
(2) Occurs when running tests with Jest
(3) Occurs only when blocktime is set to a value greater than zero.
(4) Doesn't cause tests to fail (more of a warning?)
(5) Something is occurring on setup of a Ganache provider since I've had this error pop up by running tests that only initialize the provider object
(6) I have tried adding a generic `throw Error` line right before the line in question and I have had the error message reproduced without ever throwing my custom error. Some process seems to be running this code and bypassing my Error(??)

Anyways, would love to hear someone else's thoughts on this? Its frustrating to sometime have this error and sometimes not. This PR adds a bandaid fix that first checks if `this.mining_interval_timeout` is defined.

