### PR TITLE
Allow defaultBlock parameter for calls

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -420,22 +420,24 @@ BlockchainDouble.prototype.sortByPriceAndNonce = function() {
 
 BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
   var self = this;
-  var startingStateRoot = self.stateTrie.root;
+  var startingStateRoot;
 
   var cleanUpAndReturn = function (err, result, changeRoot) {
-    // For defaultBlock, undo state root changes
-    if (changeRoot){
-      self.stateTrie.root = startingStateRoot;
-    }
-
     self.vm.stateManager.revert(function (e) {
+      // For defaultBlock, undo state root changes
+      if (changeRoot){
+        self.stateTrie.root = startingStateRoot;
+      }
       callback(err || e, result);
     });
   };
 
   var runCall = function(tx, changeRoot, err, block){
+    if (err) return callback(err);
+
     // For defaultBlock, use that block's root
     if (changeRoot){
+      startingStateRoot = self.stateTrie.root;
       self.stateTrie.root = block.header.stateRoot;
     }
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -77,11 +77,11 @@ BlockchainDouble.prototype.initialize = function(accounts, callback) {
             try {
               number = to.number(number)
             } catch (e) {
-              // Do nothing; must be a block hash. 
+              // Do nothing; must be a block hash.
             }
 
             self.getBlock(number, done)
-          } 
+          }
         },
         enableHomestead: true,
         activatePrecompiles: true
@@ -418,28 +418,34 @@ BlockchainDouble.prototype.sortByPriceAndNonce = function() {
   self.pending_transactions = sorted_transactions;
 };
 
-BlockchainDouble.prototype.processCall = function(tx, callback) {
+BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
   var self = this;
+  var startingStateRoot = self.stateTrie.root;
 
+  var cleanUpAndReturn = function (err, result, changeRoot) {
+    // For defaultBlock, undo state root changes
+    if (changeRoot){
+      self.stateTrie.root = startingStateRoot;
+    }
 
-  self.latestBlock(function (err, latestBlock) {
-    if (err) {
-      return callback(err);
+    self.vm.stateManager.revert(function (e) {
+      callback(err || e, result);
+    });
+  };
+
+  var runCall = function(tx, changeRoot, err, block){
+    // For defaultBlock, use that block's root
+    if (changeRoot){
+      self.stateTrie.root = block.header.stateRoot;
     }
 
     // create a fake block with this fake transaction
-    self.createBlock(latestBlock, function(err, block) {
+    self.createBlock(block, function(err, block) {
       block.transactions.push(tx);
 
       // We checkpoint here for speed. We want all state trie reads/writes to happen in memory,
       // and the final output be flushed to the database at the end of transaction processing.
       self.vm.stateManager.checkpoint();
-
-      var cleanUpAndReturn = function (err, result) {
-        self.vm.stateManager.revert(function (e) {
-          callback(err || e, result);
-        });
-      };
 
       var runArgs = {
         tx: tx,
@@ -460,10 +466,15 @@ BlockchainDouble.prototype.processCall = function(tx, callback) {
         // If no error, check for a runtime error. This can return null if no runtime error.
         vmerr = RuntimeError.fromResults([tx], { results: [result] });
 
-        cleanUpAndReturn(vmerr, result);
+        cleanUpAndReturn(vmerr, result, changeRoot);
       });
-    })
-  });
+    });
+  };
+
+  // Delegate block selection
+  (blockNumber === 'latest')
+    ? self.latestBlock(runCall.bind(null, tx, false))
+    : self.getBlock(blockNumber, runCall.bind(null, tx, true));
 }
 
 /**

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -250,7 +250,7 @@ StateManager.prototype.queueRawTransaction = function(rawTx, callback) {
     nonce:    tx.nonce.toString('hex'),
   }
 
-  this.queueTransaction("eth_sendRawTransaction", txParams, callback);
+  this.queueTransaction("eth_sendRawTransaction", txParams, null, callback);
 };
 
 StateManager.prototype.queueStorage = function(address, position, block, callback) {
@@ -266,7 +266,7 @@ StateManager.prototype.queueStorage = function(address, position, block, callbac
   this.processNextAction();
 }
 
-StateManager.prototype.queueTransaction = function(method, tx_params, callback) {
+StateManager.prototype.queueTransaction = function(method, tx_params, block_number, callback) {
   if (tx_params.from == null) {
     callback(new TXRejectedError("from not found; is required"));
     return;
@@ -351,7 +351,8 @@ StateManager.prototype.queueTransaction = function(method, tx_params, callback) 
     method: method,
     from: tx_params.from,
     tx: rawTx,
-    callback: callback
+    callback: callback,
+    blockNumber: block_number,
   });
 
   // We know there's work, so get started.
@@ -413,9 +414,9 @@ StateManager.prototype.processNextAction = function(override) {
   } else if (queued.method == "eth_sendTransaction" || queued.method == "eth_sendRawTransaction") {
     this.processTransaction(queued.from, queued.tx, intermediary);
   } else if (queued.method == "eth_call") {
-    this.processCall(queued.from, queued.tx, intermediary);
+    this.processCall(queued.from, queued.tx, queued.blockNumber, intermediary);
   } else if (queued.method == "eth_estimateGas") {
-    this.processGasEstimate(queued.from, queued.tx, intermediary);
+    this.processGasEstimate(queued.from, queued.tx, queued.blockNumber, intermediary);
   }
 };
 
@@ -525,13 +526,13 @@ StateManager.prototype.processBlocks = function(total_blocks, callback) {
   });
 };
 
-StateManager.prototype.processCall = function (from, rawTx, callback) {
+StateManager.prototype.processCall = function (from, rawTx, blockNumber, callback) {
   var self = this;
 
   self.createFakeTransactionWithCorrectNonce(rawTx, from, function(err, tx) {
     if (err) return callback(err);
 
-    self.blockchain.processCall(tx, function (err, results) {
+    self.blockchain.processCall(tx, blockNumber, function (err, results) {
       if (err) {
         return callback(err);
       }
@@ -548,13 +549,13 @@ StateManager.prototype.processCall = function (from, rawTx, callback) {
   });
 };
 
-StateManager.prototype.processGasEstimate = function (from, rawTx, callback) {
+StateManager.prototype.processGasEstimate = function (from, rawTx, blockNumber, callback) {
   var self = this;
 
   self.createFakeTransactionWithCorrectNonce(rawTx, from, function(err, tx) {
     if (err) return callback(err);
 
-    self.blockchain.processCall(tx, function (err, results) {
+    self.blockchain.processCall(tx, blockNumber, function (err, results) {
       if (err) {
         return callback(err);
       }

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,7 +277,7 @@ GethApiDouble.prototype.eth_sign = function(address, dataToSign, callback) {
 };
 
 GethApiDouble.prototype.eth_sendTransaction = function(tx_data, callback) {
-  this.state.queueTransaction("eth_sendTransaction", tx_data, callback);
+  this.state.queueTransaction("eth_sendTransaction", tx_data, null, callback);
 };
 
 GethApiDouble.prototype.eth_sendRawTransaction = function(rawTx, callback) {
@@ -288,14 +288,15 @@ GethApiDouble.prototype.eth_call = function(tx_data, block_number, callback) {
   if (!tx_data.gas) {
     tx_data.gas = this.state.blockchain.blockGasLimit;
   }
-  this.state.queueTransaction("eth_call", tx_data, callback);
+
+  this.state.queueTransaction("eth_call", tx_data, block_number, callback); // :(
 };
 
 GethApiDouble.prototype.eth_estimateGas = function(tx_data, block_number, callback) {
   if (!tx_data.gas) {
     tx_data.gas = this.state.blockchain.blockGasLimit;
   }
-  this.state.queueTransaction("eth_estimateGas", tx_data, callback);
+  this.state.queueTransaction("eth_estimateGas", tx_data, block_number, callback);
 };
 
 GethApiDouble.prototype.eth_getStorageAt = function(address, position, block_number, callback) {
@@ -450,7 +451,7 @@ GethApiDouble.prototype.personal_sendTransaction = function(tx_data, password, c
   self.personal_unlockAccount(from, password, null, function(err) {
     if (err) return callback(err);
 
-    self.state.queueTransaction("eth_sendTransaction", tx_data, function(err, ret) {
+    self.state.queueTransaction("eth_sendTransaction", tx_data, null, function(err, ret) {
       self.state.unlocked_accounts[from.toLowerCase()] = false;
       callback(err, ret);
     });


### PR DESCRIPTION
Modifies `processCall` to accept a `defaultBlock` parameter and run against the specified block. Borrows logic from `processTrace` as suggested by @benjamincburns in a discussion last week. 

Relevant open issue is [ganache-cli 385](https://github.com/trufflesuite/ganache-cli/issues/385). The feature request there is to support `defaultBlock` where ever the RPC spec permits. At the moment this PR is just one step in that direction - maybe it should be expanded? 

Happy to make whatever revisions might be helpful :)

 