### PR TITLE
Fix JSON encoding of Log & Receipt

### DIFF
--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -19,14 +19,17 @@ function Log(data) {
 }
 
 Log.prototype.toJSON = function() {
+  // RPC quantity values like this.transactionIndex can be set to "0x00",
+  // use the explicit rpcQuantityHexString to properly format the JSON, removing leading zeroes.
+  // See RPC log format spec: https://github.com/ethereum/wiki/wiki/JSON-RPC
   return {
-    logIndex: this.logIndex,
-    transactionIndex: to.hex(this.transactionIndex),
-    transactionHash: to.hex(this.transactionHash),
-    blockHash: to.hex(this.block.hash()),
-    blockNumber: to.hex(this.block.header.number),
-    address: to.hex(this.address),
-    data: to.hex(this.data),
+    logIndex: to.rpcQuantityHexString(this.logIndex),
+    transactionIndex: to.rpcQuantityHexString(this.transactionIndex),
+    transactionHash: to.rpcDataHexString(this.transactionHash),
+    blockHash: to.rpcDataHexString(this.block.hash()),
+    blockNumber: to.rpcQuantityHexString(this.block.header.number),
+    address: to.rpcDataHexString(this.address),
+    data: to.rpcDataHexString(this.data),
     topics: this.topics,
     type: "mined"
   };

--- a/lib/utils/receipt.js
+++ b/lib/utils/receipt.js
@@ -23,17 +23,18 @@ function Receipt(tx, block, logs, gasUsed, contractAddress, status, logsBloom) {
 Receipt.prototype.toJSON = function() {
   if (this.data != null) return data;
 
+  // Enforce Hex formatting as defined in the RPC spec.
   return {
-    transactionHash: to.hex(this.tx.hash()),
-    transactionIndex: to.hex(this.transactionIndex),
-    blockHash: to.hex(this.block.hash()),
-    blockNumber: to.hex(this.block.header.number),
-    gasUsed: to.hex(this.gasUsed),
-    cumulativeGasUsed: to.hex(this.block.header.gasUsed),
-    contractAddress: this.contractAddress != null ? to.hex(this.contractAddress) : null,
+    transactionHash: to.rpcDataHexString(this.tx.hash()),
+    transactionIndex: to.rpcQuantityHexString(this.transactionIndex),
+    blockHash: to.rpcDataHexString(this.block.hash()),
+    blockNumber: to.rpcQuantityHexString(this.block.header.number),
+    gasUsed: to.rpcQuantityHexString(this.gasUsed),
+    cumulativeGasUsed: to.rpcQuantityHexString(this.block.header.gasUsed),
+    contractAddress: this.contractAddress != null ? to.rpcDataHexString(this.contractAddress) : null,
     logs: this.logs.map(function(log) {return log.toJSON()}),
-    status: to.hex(this.status),
-    logsBloom: to.hex(this.logsBloom)
+    status: to.rpcQuantityHexString(this.status),
+    logsBloom: to.rpcDataHexString(this.logsBloom)
   }
 };
 

--- a/test/hex.js
+++ b/test/hex.js
@@ -97,8 +97,10 @@ describe("JSON-RPC Response", function() {
         "id": 2
       };
 
-      provider.sendAsync(request, function(err, result) {
-        noLeadingZeros('eth_sendTransaction', result);
+      provider.sendAsync(request, function() {
+        // Ignore eth_sendTransaction result, it returns the transaction hash.
+        // A transaction hash is a 'DATA' type, which can have leading zeroes
+        // to pad it to an even string length (4 bit per char, so whole bytes).
 
         request = {
           "jsonrpc": "2.0",


### PR DESCRIPTION
Fix JSON encoding of Log & Receipt; respect data/quantity format types (no leading zeroes for quantities)

As you may already know, the RPC format defines `DATA` and `QUANTITY` hex formats:
- `DATA` has leading zeroes, padding length to a multiple of 2
- `QUANTITY` may not have any leading zeroes

The log/receipt JSON encodings in the Ganache RPC turned out to be invalid sometimes, i.e. leading zeroes in quantities. Go-ethereum failed to decode the `eth_getLogs` RPC responses, as it strictly enforces the formatting as defined in the spec.

You can find a clear spec of the `DATA`/`QUANTITY` properties in the ethereum wiki:

Receipt: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt
Logs: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterchanges

I changed the `toJSON` methods of `Log` and `Receipt` to call the `to.rpcQuantityHexString` and `to.rpcDataHexString`, to force proper formatting (these methods where already made available for some other RPC formatting).
Note that the previous implementation, `to.hex`, didn't pad with zeroes, but also didn't enforce the spec. (E.g. call `hex("0x0123")` for a quantity and you get `"0x0123"`).


