### PR TITLE
Preserve transaction signatures.

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -250,6 +250,14 @@ StateManager.prototype.queueRawTransaction = function(rawTx, callback) {
     nonce:    tx.nonce.toString('hex'),
   }
 
+  if (tx.v && tx.v.length > 0 &&
+      tx.r && tx.r.length > 0 &&
+      tx.s && tx.s.length > 0) {
+    txParams.v = tx.v.toString('hex');
+    txParams.r = tx.r.toString('hex');
+    txParams.s = tx.s.toString('hex');
+  }
+
   this.queueTransaction("eth_sendRawTransaction", txParams, null, callback);
 };
 
@@ -314,6 +322,12 @@ StateManager.prototype.queueTransaction = function(method, tx_params, block_numb
 
   if (tx_params.nonce != null) {
     rawTx.nonce = utils.addHexPrefix(tx_params.nonce);
+  }
+
+  if (tx_params.v != null && tx_params.s != null && tx_params.v != null) {
+    rawTx.v = utils.addHexPrefix(tx_params.v);
+    rawTx.r = utils.addHexPrefix(tx_params.r);
+    rawTx.s = utils.addHexPrefix(tx_params.s);
   }
 
   // some tools use a null or empty `to` field when doing contract deployments

--- a/lib/utils/txhelper.js
+++ b/lib/utils/txhelper.js
@@ -12,7 +12,7 @@ module.exports = {
         break;
       }
     }
-    return {
+    var resultJSON = {
       hash: to.hex(tx.hash()),
       nonce: to.hex(tx.nonce),
       blockHash: to.hex(block.hash()),
@@ -25,6 +25,16 @@ module.exports = {
       gasPrice: to.hex(tx.gasPrice),
       input: to.hex(tx.data),
     };
+
+    if (tx.v && tx.v.length > 0 &&
+        tx.r && tx.r.length > 0 &&
+        tx.s && tx.s.length > 0) {
+      resultJSON.v = to.hex(tx.v);
+      resultJSON.r = to.hex(tx.r);
+      resultJSON.s = to.hex(tx.s);
+    }
+
+    return resultJSON;
   },
 
   fromJSON: function(json) {
@@ -36,6 +46,14 @@ module.exports = {
       gasPrice: utils.toBuffer(to.hex(json.gasPrice)),
       data: utils.toBuffer(to.hex(json.input))
     });
+
+    if (json.v && json.v.length > 0 &&
+        json.r && json.r.length > 0 &&
+        json.s && json.s.length > 0) {
+      tx.v = utils.toBuffer(to.hex(json.v));
+      tx.r = utils.toBuffer(to.hex(json.r));
+      tx.s = utils.toBuffer(to.hex(json.s));
+    }
 
     if (json.to) {
       // Remove all padding and make it easily comparible.

--- a/test/requests.js
+++ b/test/requests.js
@@ -444,6 +444,26 @@ var tests = function(web3) {
     })
 
 
+    it("should respond with correct txn hash", function(done) {
+      var provider = web3.currentProvider;
+      var transaction = new Transaction({
+        "value": "0x00",
+        "gasLimit": "0x5208",
+        "from": accounts[0],
+        "to": accounts[1],
+        "nonce": "0x02"
+      })
+
+      var secretKeyBuffer = Buffer.from(secretKeys[0].substr(2), 'hex')
+      transaction.sign(secretKeyBuffer)
+
+      web3.eth.sendSignedTransaction(transaction.serialize(), function(err, result) {
+        assert.equal(result, to.hex(transaction.hash()))
+        done(err)
+      })
+
+    })
+
   })
 
   describe("contract scenario", function() {


### PR DESCRIPTION
This fixes transaction hashes being computed incorrectly for signed messages submitted via eth_sendRawTransaction.

This should fix #56 .