### PR TITLE
implement eth_estimateGas as binary search

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"ws"`: Enable a websocket server. This is `true` by default.
 * `"vmErrorsOnRPCResponse"`: Whether to report runtime errors from EVM code as RPC errors. This is `true` by default to replicate the error reporting behavior of previous versions of ganache.
 * `"hdPath"`: The hierarchical deterministic path to use when generating accounts. Default: "m/44'/60'/0'/0/"
+* `"estimateGasThreshold"`: Minimum threshold for estimateGas response. The bigger the number, the faster but less accurate (response is always >= actual gas required for the tx) the estimateGas response is. Default is 50000
 
 # IMPLEMENTED METHODS
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -21,6 +21,8 @@ var random = require('./utils/random');
 var txhelper = require('./utils/txhelper');
 var TXRejectedError = require('./utils/txrejectederror');
 
+var DEFAULT_ESTIMATE_GAS_THRESHOLD = 50000;
+
 StateManager = function(options, provider) {
   var self = this;
 
@@ -41,6 +43,10 @@ StateManager = function(options, provider) {
   this.personal_accounts = {}
   this.total_accounts = options.total_accounts;
   this.coinbase = null;
+
+  // gas diff has to be < threshold, so min threshold is 1
+  if (options.estimateGasThreshold === 0) options.estimateGasThreshold = 1;
+  this.estimateGasThreshold = options.estimateGasThreshold || DEFAULT_ESTIMATE_GAS_THRESHOLD;
 
   this.latest_filter_id = 1;
 
@@ -569,23 +575,94 @@ StateManager.prototype.processCall = function (from, rawTx, blockNumber, callbac
 };
 
 StateManager.prototype.processGasEstimate = function (from, rawTx, blockNumber, callback) {
+  // inspired by https://github.com/MetaMask/provider-engine/blob/d32ef4f0206c4323690125201f73934253fca4e5/subproviders/vm.js#L67
   var self = this;
 
   self.createFakeTransactionWithCorrectNonce(rawTx, from, function(err, tx) {
     if (err) return callback(err);
 
-    self.blockchain.processCall(tx, blockNumber, function (err, results) {
+    var tx_hash = to.hex(tx.hash());
+    var lo = 0
+    var hi = to.number(self.blockchain.blockGasLimit);
+    var now = new Date().getTime();
+    var iterations = 0
+
+    var prevGasLimit = to.number(self.blockchain.blockGasLimit);
+
+    tx.gasLimit = utils.toBuffer(hi);
+
+    async.series([
+      setLo,
+      binarySearch
+    ], function(err) {
       if (err) {
-        return callback(err);
-      }
-      var result = '0x0'
-      if (!results.error) {
-        result = to.hex(results.gasUsed)
+        if (err === '0x0') return callback(null, '0x0');
+        return callback(err)
       } else {
-        self.logger.log(`Error calculating gas estimate: ${results.error}`)
+        var took = new Date().getTime() - now;
+        if (took > 1000 && self.estimateGasThreshold < DEFAULT_ESTIMATE_GAS_THRESHOLD) {
+          self.logger.log(`Calculating gas estimate took: ${took} ms and ${iterations} iterations. You may want to increase the value of the estimateGasThreshold option to speed up the calculation.`);
+        }
+        hi = Math.floor(hi)
+        return callback(null, to.hex(hi));
       }
-      return callback(null, result);
-    });
+    })
+
+    function setLo(cb) {
+      // by setting the lo, this cuts approx 2 iterations off the binary search
+      // as well as potentially allowing us to short circuit the binary search
+      // self.blockchain.processCall(tx, function (err, results) {
+      self.blockchain.processCall(tx, blockNumber, function (err, results) {
+        if (err) return cb(err)
+        if (!results.error) {
+          lo = results.gasUsed.iadd(results.vm.gasRefund).toNumber()
+        } else {
+          self.logger.log(`Error calculating gas estimate: ${results.error}`)
+          return cb('0x0');
+        }
+        cb()
+      })
+    }
+
+    function binarySearch (cb) {
+      tx.gasLimit = utils.toBuffer(lo)
+      // try w/ new lo gasLimit
+      self.blockchain.processCall(tx, blockNumber, function (err, results) {
+        // if it succeeded, then we're good. no need to do a binary search
+        if (!err && !results.error && results.gasUsed.gtn(0)) {
+          hi = lo
+          return cb()
+        }
+
+        // otherwise do a binary search
+        async.doWhilst(
+          function (cb2) {
+            iterations++
+            // Take a guess at the gas, and check transaction validity
+            var mid = Math.floor((hi + lo) / 2)
+            tx.gasLimit = utils.toBuffer(mid)
+            self.blockchain.processCall(tx, blockNumber, function (err, results) {
+              gasUsed = err ? self.blockchain.blockGasLimit : to.number(results.gasUsed)
+              if (err || results.error || gasUsed === 0) {
+                lo = mid
+              } else {
+                hi = mid
+                // Perf improvement: stop the binary search when the difference in gas between two iterations
+                // is less then `estimateGasThreshold`. Doing this cuts the number of iterations from 23
+                // to 12, with only a ~1000 gas loss in precision.
+                if (Math.abs(prevGasLimit - mid) < self.estimateGasThreshold) {
+                  lo = hi
+                }
+              }
+              prevGasLimit = mid
+              cb2()
+            })
+          },
+          function () { return lo + 1 < hi },
+          cb
+        )
+      })
+    }
   });
 }
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -294,9 +294,6 @@ GethApiDouble.prototype.eth_call = function(tx_data, block_number, callback) {
 };
 
 GethApiDouble.prototype.eth_estimateGas = function(tx_data, block_number, callback) {
-  if (!tx_data.gas) {
-    tx_data.gas = this.state.blockchain.blockGasLimit;
-  }
   this.state.queueTransaction("eth_estimateGas", tx_data, block_number, callback);
 };
 

--- a/test/EstimateGas.sol
+++ b/test/EstimateGas.sol
@@ -13,6 +13,7 @@ contract EstimateGas {
 
     mapping(bytes32 => uint) index;
     Test[] tests;
+    string field;
 
     function EstimateGas() {
         tests.length++;
@@ -62,5 +63,13 @@ contract EstimateGas {
         tests[pos].balances[posTo] += _value;
 
         return true;
+    }
+
+	function setField(string value) {
+	    // This check will screw gas estimation! Good, good!
+   	    if (msg.gas < 100000) {
+		    throw;
+	    }
+	    field = value;
     }
 }


### PR DESCRIPTION
fixes #26 

This fix implements a binary search for the gas estimate. The main disadvantage is that `eth_estimateGas` calls are slower as the tx needs to be processed 2 - ~12 times to find a `gasLimit` that will successfully run the tx.

I've also added an option to set the accuracy threshold. The higher the threshold, the less accurate (will always be > then required) the gas estimate and the faster the response.