### PR TITLE
Handle method eth_signTypedData

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -1,5 +1,6 @@
 var Account = require('ethereumjs-account');
 var Block = require('ethereumjs-block');
+var Abi = require('ethereumjs-abi');
 var VM = require('ethereumjs-vm');
 var RuntimeError = require('./utils/runtimeerror');
 var Trie = require('merkle-patricia-tree');
@@ -450,6 +451,28 @@ StateManager.prototype.sign = function(address, dataToSign) {
   var msg = new Buffer(dataToSign.replace('0x',''), 'hex');
   var msgHash = utils.hashPersonalMessage(msg);
   var sgn = utils.ecsign(msgHash, new Buffer(secretKey));
+  return utils.toRpcSig(sgn.v, sgn.r, sgn.s);
+};
+
+StateManager.prototype.signTypedData = function(address, typedData) {
+  var account = this.accounts[to.hex(address).toLowerCase()];
+
+  if (!account) {
+    throw new Error("cannot sign data; no private key");
+  }
+
+  var secretKey = account.secretKey;
+  const data = _.map(typedData, 'value');
+  const types = _.map(typedData, 'type');
+  const schema = _.map(typedData, entry => `${entry.type} ${entry.name}`);
+  const msgHash = Abi.soliditySHA3(
+    ['bytes32', 'bytes32'],
+    [
+      Abi.soliditySHA3(_.times(typedData.length, _.constant('string')), schema),
+      Abi.soliditySHA3(types, data),
+    ]
+  );
+  const sgn = utils.ecsign(msgHash, new Buffer(secretKey));
   return utils.toRpcSig(sgn.v, sgn.r, sgn.s);
 };
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,6 +277,19 @@ GethApiDouble.prototype.eth_sign = function(address, dataToSign, callback) {
   callback(error, result);
 };
 
+GethApiDouble.prototype.eth_signTypedData = function(address, typedData, callback) {
+  var result;
+  var error;
+
+  try {
+    result = this.state.signTypedData(address, typedData);
+  } catch (e) {
+    error = e;
+  }
+
+  callback(error, result);
+};
+
 GethApiDouble.prototype.eth_sendTransaction = function(tx_data, callback) {
   this.state.queueTransaction("eth_sendTransaction", tx_data, null, callback);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,6 +1769,29 @@
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
       "integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
     },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "ethereumjs-util": "4.5.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "requires": {
+            "bn.js": "4.11.6",
+            "create-hash": "1.1.3",
+            "keccakjs": "0.2.1",
+            "rlp": "2.0.0",
+            "secp256k1": "3.4.0"
+          }
+        }
+      }
+    },
     "ethereumjs-account": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cachedown": "^1.0.0",
     "chai": "^3.5.0",
     "clone": "^2.1.1",
+    "ethereumjs-abi": "^0.6.5",
     "ethereumjs-account": "~2.0.4",
     "ethereumjs-block": "~1.2.2",
     "ethereumjs-tx": "^1.3.0",


### PR DESCRIPTION
Adding a function to `geth_api_double.js` and `statemanager.js` to handle the method `eth_signTypedData`. This is in reference to ethereum/EIPs#712. Although this EIP is not yet a standard, it has been experimentally implemented in Metamask 3.11.0+ and is also being touted by much of the community as the best way forward for signing data.



