### PR TITLE
Consume gasRefund From Potential ethereumjs-vm Addition

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -580,7 +580,7 @@ StateManager.prototype.processGasEstimate = function (from, rawTx, blockNumber, 
       }
       var result = '0x0'
       if (!results.error) {
-        result = to.hex(results.gasUsed)
+        result = results.gasRefund ? to.hex(results.gasUsed.add(results.gasRefund)) : to.hex(results.gasUsed);
       } else {
         self.logger.log(`Error calculating gas estimate: ${results.error}`)
       }


### PR DESCRIPTION
This fixes case 1 in #26, but will require the merging of PR https://github.com/ethereumjs/ethereumjs-vm/pull/284 before fixed.

This PR adds the gasRefund to the estimated gas call. This can be merged prior to https://github.com/ethereumjs/ethereumjs-vm/pull/284 being merged, but may be fruitless to do so until https://github.com/ethereumjs/ethereumjs-vm/pull/284 is merged to maintain cohesion and ensuring the problem does end up fixing #26.

More discussion can be found on #26 and https://github.com/ethereumjs/ethereumjs-vm/issues/283