### PR TITLE
added eth_ecrecover function:

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -467,15 +467,17 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.toRpcSig(sgn.v, sgn.r, sgn.s);
 };
 
-StateManager.prototype.ecRecover = function(msgHash, signature) {
+StateManager.prototype.ecRecover = function(msgHex, signature) {
   var self = this;
-  var msg = utils.toBuffer(msgHash);
+  var msg = new Buffer(msgHex.replace('0x',''), 'hex');
+  var msgHash = utils.hashPersonalMessage(msg);
+  var msgbuf = utils.toBuffer(msgHash);
   var sig = utils.stripHexPrefix(signature);
   var r = new Buffer(sig.slice(0, 64), 'hex');
   var s = new Buffer(sig.slice(64, 128), 'hex');
   var v = parseInt(sig.slice(128, 130), 16) + 27;
 
-  var pub = utils.ecrecover(msg, v, r, s);
+  var pub = utils.ecrecover(msgbuf, v, r, s);
   var addr = utils.setLength(utils.fromSigned(utils.pubToAddress(pub)), 20);
   addr = to.hex(addr);
   return addr;

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -467,6 +467,20 @@ StateManager.prototype.sign = function(address, dataToSign) {
   return utils.toRpcSig(sgn.v, sgn.r, sgn.s);
 };
 
+StateManager.prototype.ecRecover = function(msgHash, signature) {
+  var self = this;
+  var msg = utils.toBuffer(msgHash);
+  var sig = utils.stripHexPrefix(signature);
+  var r = new Buffer(sig.slice(0, 64), 'hex');
+  var s = new Buffer(sig.slice(64, 128), 'hex');
+  var v = parseInt(sig.slice(128, 130), 16) + 27;
+
+  var pub = utils.ecrecover(msg, v, r, s);
+  var addr = utils.setLength(utils.fromSigned(utils.pubToAddress(pub)), 20);
+  addr = to.hex(addr);
+  return addr;
+};
+
 StateManager.prototype.printTransactionReceipt = function(tx_hash, error, callback){
   var self = this;
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,6 +277,19 @@ GethApiDouble.prototype.eth_sign = function(address, dataToSign, callback) {
   callback(error, result);
 };
 
+GethApiDouble.prototype.eth_ecRecover = function(msgHash, signature, callback) {
+  var result;
+  var error;
+
+  try {
+    result = this.state.ecRecover(msgHash, signature);
+  } catch (e) {
+    error = e;
+  }
+
+  callback(error, result);
+};
+
 GethApiDouble.prototype.eth_sendTransaction = function(tx_data, callback) {
   this.state.queueTransaction("eth_sendTransaction", tx_data, null, callback);
 };

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -277,12 +277,12 @@ GethApiDouble.prototype.eth_sign = function(address, dataToSign, callback) {
   callback(error, result);
 };
 
-GethApiDouble.prototype.eth_ecRecover = function(msgHash, signature, callback) {
+GethApiDouble.prototype.eth_ecRecover = function(msgHex, signature, callback) {
   var result;
   var error;
 
   try {
-    result = this.state.ecRecover(msgHash, signature);
+    result = this.state.ecRecover(msgHex, signature);
   } catch (e) {
     error = e;
   }

--- a/test/requests.js
+++ b/test/requests.js
@@ -382,6 +382,56 @@ var tests = function(web3) {
 
   });
 
+  describe("eth_ecRecover", function() {
+    var accounts;
+    var signingWeb3;
+
+    // This account produces an edge case signature when it signs the hex-encoded buffer:
+    // '0x07091653daf94aafce9acf09e22dbde1ddf77f740f9844ac1f0ab790334f0627'. (See Issue #190)
+    var acc = {
+      balance: "0x00",
+      secretKey: "0xe6d66f02cd45a13982b99a5abf3deab1f67cf7be9fee62f0a072cb70896342e4"
+    };
+
+    // Load account.
+    before(function( done ){
+      signingWeb3 = new Web3();
+      signingWeb3.setProvider(Ganache.provider({
+        accounts: [ acc ]
+      }));
+      signingWeb3.eth.getAccounts(function(err, accs) {
+        if (err) return done(err);
+        accounts = accs.map(function(val) {
+          return val.toLowerCase();
+        });
+        done();
+      });
+    });
+
+    it("should return the address of the account signing a message", function() {
+      var msgHex = '0x07091653daf94aafce9acf09e22dbde1ddf77f740f9844ac1f0ab790334f0627';
+      var edgeCaseMsg = utils.toBuffer(msgHex);
+      var msgHash = utils.hashPersonalMessage(edgeCaseMsg);
+      return signingWeb3.eth.sign(msgHex, accounts[0]).then(sgn => {
+        sgn = utils.stripHexPrefix(sgn);
+        var r = new Buffer(sgn.slice(0, 64), 'hex');
+        var s = new Buffer(sgn.slice(64, 128), 'hex');
+        var v = parseInt(sgn.slice(128, 130), 16) + 27;
+        var pub = utils.ecrecover(msgHash, v, r, s);
+        var addr = utils.setLength(utils.fromSigned(utils.pubToAddress(pub)), 20);
+        addr = to.hex(addr);
+        assert.deepEqual(addr, accounts[0]);
+      });
+    });
+
+    after("shutdown", function(done) {
+      let provider = signingWeb3._provider;
+      signingWeb3.setProvider()
+      provider.close(done)
+    });
+
+  });
+
   describe('eth_sendRawTransaction', () => {
 
     it("should fail with bad nonce (too low)", function(done) {


### PR DESCRIPTION
Added a function that allows the recovery of a signer's ethereum address from a signature created with ecsign (this method is already in the repo). ecrecover is also already used as a test for ecsign (in tests/requests.js), and this implementation (and the test) takes the same format. 

Commits were messy first time around -- tidied it up for clarity. Feedback appreciated + thanks!