### PR TITLE
Fix for deployment transactions without a to address.

### DIFF
--- a/lib/utils/txhelper.js
+++ b/lib/utils/txhelper.js
@@ -12,6 +12,8 @@ module.exports = {
         break;
       }
     }
+
+
     var resultJSON = {
       hash: to.hex(tx.hash()),
       nonce: to.hex(tx.nonce),
@@ -19,12 +21,14 @@ module.exports = {
       blockNumber: to.hex(block.header.number),
       transactionIndex: to.hex(transactionIndex),
       from: to.hex(tx.from),
-      to: to.hex(tx.to),
+      to: null,
       value: to.hex(tx.value),
       gas: to.hex(tx.gasLimit),
       gasPrice: to.hex(tx.gasPrice),
       input: to.hex(tx.data),
     };
+
+    if (tx.to && tx.length) { resultJSON.to = to.hex(tx.to); }
 
     if (tx.v && tx.v.length > 0 &&
         tx.r && tx.r.length > 0 &&


### PR DESCRIPTION
Fix for https://github.com/trufflesuite/ganache/issues/425.

Transactions without a `to` should have `null`, not `0x0000...0000`.

I believe this may be an issue for other values in this function, but this is the only one I have confirmed (and tested against. It is causing issues in [ethers.js](https://github.com/ethers-io/ethers.js), since it is a valid address, the `creates` is not being populated properly.