### PR TITLE
Align block_helper.toJSON with hashed values

### DIFF
--- a/lib/utils/block_helper.js
+++ b/lib/utils/block_helper.js
@@ -7,7 +7,7 @@ module.exports = {
       number: to.rpcQuantityHexString(block.header.number),
       hash: to.hex(block.hash()),
       parentHash: to.hex(block.header.parentHash), //common.hash
-      mixHash: "0x" + (new Array(32).fill("10").join("")), // TODO: Figure out what to do here.
+      mixHash: to.hex(block.header.mixHash),
       nonce: to.rpcDataHexString(to.hex(block.header.nonce), 16),
       sha3Uncles: to.hex(block.header.uncleHash),
       logsBloom: to.hex(block.header.bloom),
@@ -17,7 +17,7 @@ module.exports = {
       miner: to.hex(block.header.coinbase),
       difficulty: to.hex(block.header.difficulty),
       totalDifficulty: to.hex(block.header.difficulty), // TODO: Figure out what to do here.
-      extraData: to.rpcDataHexString(to.hex(block.header.extraData)),
+      extraData: to.rpcDataHexString(block.header.extraData),
       size: to.hex(1000), // TODO: Do something better here
       gasLimit: to.hex(block.header.gasLimit),
       gasUsed: to.hex(block.header.gasUsed),

--- a/lib/utils/block_helper.js
+++ b/lib/utils/block_helper.js
@@ -15,13 +15,13 @@ module.exports = {
       stateRoot: to.hex(block.header.stateRoot),
       receiptsRoot: to.hex(block.header.receiptTrie),
       miner: to.hex(block.header.coinbase),
-      difficulty: to.hex(block.header.difficulty),
-      totalDifficulty: to.hex(block.header.difficulty), // TODO: Figure out what to do here.
+      difficulty: to.rpcQuantityHexString(block.header.difficulty),
+      totalDifficulty: to.rpcQuantityHexString(block.header.difficulty), // TODO: Figure out what to do here.
       extraData: to.rpcDataHexString(block.header.extraData),
       size: to.hex(1000), // TODO: Do something better here
-      gasLimit: to.hex(block.header.gasLimit),
-      gasUsed: to.hex(block.header.gasUsed),
-      timestamp: to.hex(block.header.timestamp),
+      gasLimit: to.rpcQuantityHexString(block.header.gasLimit),
+      gasUsed: to.rpcQuantityHexString(block.header.gasUsed),
+      timestamp: to.rpcQuantityHexString(block.header.timestamp),
       transactions: block.transactions.map(function(tx) {
         if (include_full_transactions) {
           return txhelper.toJSON(tx, block);

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -47,6 +47,9 @@ module.exports = {
 
       val = new Array(length-val.length).fill("0").join("") + val;
     } else {
+      if(val.length == 0) {
+        return "0x";
+      }
       val = this.hex(val).replace("0x", "");
 
       if(val.length % 2 != 0) {

--- a/test/hex.js
+++ b/test/hex.js
@@ -30,6 +30,13 @@ describe("to.rpcQuantityHexString", function() {
   });
 });
 
+describe("to.rpcDataHexString", function() {
+  it("should differentiate between a list of 0 items and a list of one 0", function(done) {
+    assert.notEqual(to.rpcDataHexString(new Buffer("", "hex")), to.rpcDataHexString(new Buffer("00", "hex")));
+    done();
+  })
+})
+
 function noLeadingZeros(method, result, path) {
   if (!path) {
     path = 'result'

--- a/test/requests.js
+++ b/test/requests.js
@@ -162,7 +162,7 @@ var tests = function(web3) {
         var expectedFirstBlock = {
           number: 0,
           hash: block.hash, // Don't test this one
-          mixHash: "0x1010101010101010101010101010101010101010101010101010101010101010",
+          mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
           parentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           nonce: '0x0000000000000000',
           sha3Uncles: '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347',
@@ -173,7 +173,7 @@ var tests = function(web3) {
           miner: '0x0000000000000000000000000000000000000000',
           difficulty: "0",
           totalDifficulty: "0",
-          extraData: '0x00',
+          extraData: '0x',
           size: 1000,
           gasLimit: 6721975,
           gasUsed: 0,


### PR DESCRIPTION
I have a project where we're trying to use Ganache to test our services that
are written in Go. The RPC client that ships with Geth ignores the
hash provided by RPC and recalculates it instead. Due to some discrepancies
between the value used to calculate the hash and the values served over
RPC, the Go client is unable to compute the same hash as Ganache.

Two of the issues I ran into are in Ganache core. One was that the RPC
value for mixHash did not match the value used to calculate the checksum.
For reasons that are not clear even after reviewing the commit history,
rather than including the mixHash used to calculate the hash, block_helper
was including a string of repeating "10"s. I have changed this to reflect
the mixHash stored in the block header.

The other issue I ran into was extraData. If block.header.extraData was
an empty buffer, it would get encoded as "0x00", which decodes to a buffer
containing a single null byte. When a client uses that value to compute
the hash, they obviously get different results. This modifies
to.rpcDataHexString to pass empty buffers through as "0x" instead of
padding it with an extra 0 byte.

My mission of being able to compute the same hash with Ganache and  the Geth
RPC client has one more stop at ethereumjs-block, which defaults to having
an empty nonce instead of an appropriately sized buffer of null bytes.