### PR TITLE
Fix tests for web3-provider-ws@1.0.0-beta.33

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -178,7 +178,12 @@ var tests = function(web3, EventTest) {
         let filter_id = result.result;
 
         let listener = function (err, result) {
-          if (err) return done(err);
+          if(result == undefined) {
+            // If there's only one argument, it's the result, not an error
+            result = err;
+          } else if (err) {
+            return done(err);
+          }
           first_changes = result.params.result.hash;
           assert.equal(first_changes.length, 66); // Ensure we have a hash
           provider.removeAllListeners('data')


### PR DESCRIPTION
In web3-provider-ws v1.0.0-beta.33 they changed the callback behavior
from cb(err, response) to cb(response), but it seems some instances
make the callback without passing the error while other instances make
the callback with an error and response. This change deals with both
possible inputs to the callback function.

An alternative might be to pin web3-provider-ws to 1.0.0-beta.30.