### PR TITLE
Adding prototype.evm_decreaseTime

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -1042,6 +1042,12 @@ BlockchainDouble.prototype.increaseTime = function(seconds) {
   return this.timeAdjustment;
 };
 
+BlockchainDouble.prototype.decreaseTime = function(seconds) {
+  if (seconds < 0) seconds = 0;
+  this.timeAdjustment -= seconds;
+  return this.timeAdjustment;
+};
+
 BlockchainDouble.prototype.setTime = function(date) {
   var now = new Date().getTime() / 1000 | 0;
   var start = date.getTime() / 1000 | 0;

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -473,6 +473,11 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
+GethApiDouble.prototype.evm_decreaseTime = function(seconds, callback) {
+  callback(null, this.state.blockchain.decreaseTime(seconds));
+};
+
+
 GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.processBlocks(1, function(err) {
     callback(err, '0x0');


### PR DESCRIPTION
It's currently hard to perform tests that are timestamp dependent since the timestamp changes between tests are shared (E.g. see #2, [Ganache-cli-issue-390](https://github.com/trufflesuite/ganache-cli/issues/390) and [here](https://ethereum.stackexchange.com/questions/30452/is-there-the-opposite-function-for-evm-increasetime)) . Using `evm_increaseTime` leads to non-reversible timestamp changes that persist through all the tests. 

Adding `evm_decreaseTime` allow developers to revert the timestamp change after each test, using a logic such as 
```javascript
beforeEach(async function () {
  await web3.currentProvider.send({
      jsonrpc: "2.0", 
      method: "evm_increaseTime", 
      params: [timeToIncrease], 
      id: 0
  });
});

afterEach(async function () {
  await web3.currentProvider.send({
      jsonrpc: "2.0", 
      method: "evm_decreaseTime", 
      params: [timeToIncrease], 
      id: 0
  });
});
```