### PR TITLE
Rename blocktime to blockTime

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -60,8 +60,8 @@ StateManager = function(options, provider) {
   this.gasPriceVal = to.hex(options.gasPrice);
 
   this.is_mining = true;
-  this.blocktime = options.blocktime;
-  this.is_mining_on_interval = !!options.blocktime;
+  this.blockTime = options.blockTime;
+  this.is_mining_on_interval = !!options.blockTime;
   this.mining_interval_timeout = null;
 
   this._provider = provider;
@@ -181,7 +181,7 @@ StateManager.prototype.mineOnInterval = function() {
       self.mineOnInterval.bind(self)
     );
 
-  }, this.blocktime * 1000);
+  }, this.blockTime * 1000);
 
   // Ensure this won't keep a node process open.
   if (this.mining_interval_timeout.unref) {

--- a/test/interval_mining.js
+++ b/test/interval_mining.js
@@ -19,7 +19,7 @@ describe("Interval Mining", function() {
     this.timeout(5000);
 
     web3 = new Web3(Ganache.provider({
-      blocktime: 0.5, // seconds
+      blockTime: 0.5, // seconds
       mnemonic: mnemonic
     }));
 
@@ -46,7 +46,7 @@ describe("Interval Mining", function() {
     this.timeout(5000);
 
     web3 = new Web3(Ganache.provider({
-      blocktime: 0.25, // seconds
+      blockTime: 0.25, // seconds
       mnemonic: mnemonic
     }));
 
@@ -89,7 +89,7 @@ describe("Interval Mining", function() {
     this.timeout(5000);
 
     web3 = new Web3(Ganache.provider({
-      blocktime: 0.5, // seconds
+      blockTime: 0.5, // seconds
       mnemonic: mnemonic
     }));
 
@@ -153,7 +153,7 @@ describe("Interval Mining", function() {
     };
 
     web3 = new Web3(Ganache.provider({
-      blocktime: 0.5, // seconds
+      blockTime: 0.5, // seconds
       mnemonic: mnemonic,
       logger: logger
     }));

--- a/test/vm.js
+++ b/test/vm.js
@@ -19,7 +19,7 @@ var logger = {
 
 var web3 = new Web3();
 web3.setProvider(Ganache.provider({
-  /*blocktime: 100,*/
+  /*blockTime: 100,*/
   logger: logger,
   seed: "1337"
 }));


### PR DESCRIPTION
This is missing part of https://github.com/trufflesuite/ganache-cli/pull/483 which renames `blocktime` to `blockTime` and pass that property in options while ganache-core still expects property named `blocktime`

This PR renames `blocktime` to `blockTime` in ganache-core.

Fixes  https://github.com/trufflesuite/ganache-cli/issues/506