### PR TITLE
Mine n blocks, skip blocks

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -180,6 +180,26 @@ BlockchainDouble.prototype.getEffectiveBlockNumber = function(number, callback) 
   }
 };
 
+BlockchainDouble.prototype.getRealBlockNumber = function(number, callback) {
+  if (typeof number != "string") {
+    number = to.hex(number);
+  }
+
+  // If we have a hex number
+  if (number.indexOf("0x") >= 0) {
+    return callback(null, to.number(number));
+  } else {
+    if (number == "latest" || number == "pending") {
+      return this.data.blocks.length(function(err, number) {
+        if (err) return callback(err);
+        callback(null, number - 1);
+      });
+    } else if (number == "earliest") {
+      return callback(null, 0);
+    }
+  }
+};
+
 // number accepts number (integer, hex), tag (e.g., "latest") or block hash
 // This function is used by ethereumjs-vm
 BlockchainDouble.prototype.getBlock = function(number, callback) {
@@ -243,6 +263,14 @@ BlockchainDouble.prototype.putBlock = function(block, logs, receipts, callback) 
       callback(err, result);
     });
   });
+};
+
+BlockchainDouble.prototype.skipBlocks = function(numBlocks, callback) {
+  this.data.blocks.last((err, block) => {
+    if (err) return callback(err);
+    const fakeBlock = this.createFakeBlock(numBlocks, block);
+    this.putBlock(fakeBlock, [], [], callback);
+  })
 };
 
 BlockchainDouble.prototype.popBlock = function(callback) {
@@ -348,6 +376,24 @@ BlockchainDouble.prototype.createBlock = function(parent, callback) {
 
     callback(null, block);
   });
+};
+
+BlockchainDouble.prototype.createFakeBlock = function(numBlocks, parent) {
+  var block = new Block();
+
+  var parentNumber = parent != null ? to.number(parent.header.number) : -1;
+
+  block.header.gasLimit = this.blockGasLimit;
+
+  // Ensure we have the right block number for the VM.
+  block.header.number = to.hex(parentNumber + numBlocks);
+
+  // Set the timestamp before processing txs
+  block.header.timestamp = to.hex(this.currentTime());
+
+  block.header.parentHash = to.hex(parent.hash());
+
+  return block;
 };
 
 BlockchainDouble.prototype.getQueuedNonce = function(address, callback) {
@@ -1026,9 +1072,9 @@ BlockchainDouble.prototype.getBlockLogs = function(number, callback) {
 };
 
 BlockchainDouble.prototype.getHeight = function(callback) {
-  this.data.blocks.length(function(err, length) {
+  this.data.blocks.last(function(err, block) {
     if (err) return callback(err);
-    callback(null, length - 1);
+    callback(null, to.number(block.header.number));
   })
 };
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -559,6 +559,10 @@ StateManager.prototype.processBlocks = function(total_blocks, callback) {
   });
 };
 
+StateManager.prototype.skipBlocks = function(numBlocks, callback) {
+  this.blockchain.skipBlocks(numBlocks, callback);
+};
+
 StateManager.prototype.processCall = function (from, rawTx, blockNumber, callback) {
   var self = this;
 
@@ -640,73 +644,81 @@ StateManager.prototype.getBlock = function(hash_or_number, callback) {
   this.blockchain.getBlock(hash_or_number, callback);
 };
 
-StateManager.prototype.getLogs = function(filter, callback) {
-  var self = this;
-
+StateManager.prototype.getLogsCallback = function(filter, err, results, callback) {
   var expectedAddress = filter.address;
   var expectedTopics = filter.topics || [];
 
+  var self = this;
+  var fromBlock = results.fromBlock;
+  var toBlock = results.toBlock;
+  var latestBlock = results.latestBlock;
+
+  if (toBlock > latestBlock) {
+    toBlock = latestBlock;
+  }
+
+  var logs = [];
+  var current = fromBlock;
+
+  async.whilst(function() {
+    return current <= toBlock;
+  }, function(finished) {
+    self.blockchain.getBlockLogs(current, function(err, blockLogs) {
+      if (err) return finished(err);
+
+      // Filter logs that match the address
+      var filtered = blockLogs.filter(function(log) {
+        return (expectedAddress == null || log.address == expectedAddress);
+      });
+
+      // Now filter based on topics.
+      filtered = filtered.filter(function(log) {
+        var keep = true;
+        for (var i = 0; i < expectedTopics.length; i++) {
+          var expectedTopic = expectedTopics[i];
+          var logTopic = log.topics[i];
+          if (expectedTopic == null) continue;
+          var isMatch = Array.isArray(expectedTopic)
+            ? expectedTopic.includes(logTopic)
+            : expectedTopic === logTopic;
+          if (i >= log.topics.length || !isMatch) {
+            keep = false;
+            break;
+          }
+        }
+        return keep;
+      });
+
+      logs.push.apply(logs, filtered);
+
+      current += 1;
+      finished();
+    });
+  }, function(err) {
+    if (err) return callback(err);
+
+    logs = logs.map(function(log) {
+      return log.toJSON();
+    });
+
+    callback(err, logs);
+  });
+}
+
+StateManager.prototype.getLogsWithFakeBlocks = function(filter, callback) {
+  async.parallel({
+    fromBlock: this.blockchain.getRealBlockNumber.bind(this.blockchain, filter.fromBlock || "latest"),
+    toBlock: this.blockchain.getRealBlockNumber.bind(this.blockchain, filter.toBlock || "latest"),
+    latestBlock: this.blockchain.getRealBlockNumber.bind(this.blockchain, "latest")
+  }, (err, results) => this.getLogsCallback(filter, err, results, callback));
+};
+
+StateManager.prototype.getLogs = function(filter, callback) {
   async.parallel({
     fromBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, filter.fromBlock || "latest"),
     toBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, filter.toBlock || "latest"),
     latestBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, "latest")
-  }, function(err, results) {
-    var fromBlock = results.fromBlock;
-    var toBlock = results.toBlock;
-    var latestBlock = results.latestBlock;
-
-    if (toBlock > latestBlock) {
-      toBlock = latestBlock;
-    }
-
-    var logs = [];
-    var current = fromBlock;
-
-    async.whilst(function() {
-      return current <= toBlock;
-    }, function(finished) {
-      self.blockchain.getBlockLogs(current, function(err, blockLogs) {
-        if (err) return finished(err);
-
-        // Filter logs that match the address
-        var filtered = blockLogs.filter(function(log) {
-          return (expectedAddress == null || log.address == expectedAddress);
-        });
-
-        // Now filter based on topics.
-        filtered = filtered.filter(function(log) {
-          var keep = true;
-          for (var i = 0; i < expectedTopics.length; i++) {
-            var expectedTopic = expectedTopics[i];
-            var logTopic = log.topics[i];
-            if (expectedTopic == null) continue;
-            var isMatch = Array.isArray(expectedTopic)
-              ? expectedTopic.includes(logTopic)
-              : expectedTopic === logTopic;
-            if (i >= log.topics.length || !isMatch) {
-              keep = false;
-              break;
-            }
-          }
-          return keep;
-        });
-
-        logs.push.apply(logs, filtered);
-
-        current += 1;
-        finished();
-      });
-    }, function(err) {
-      if (err) return callback(err);
-
-      logs = logs.map(function(log) {
-        return log.toJSON();
-      });
-
-      callback(err, logs);
-    });
-
-  });
+  }, (err, results) => this.getLogsCallback(filter, err, results, callback));
 };
 
 // Note: Snapshots have 1-based ids.

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -473,6 +473,17 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
+GethApiDouble.prototype.evm_mineBlocks = function(numBlocks, callback) {
+  let n = numBlocks;
+  if (typeof n == "function" && callback == undefined) {
+     callback = n;
+     n = 1;
+  }
+  this.state.processBlocks(n, function(err) {
+    callback(err, '0x0');
+  });
+};
+
 GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.processBlocks(1, function(err) {
     callback(err, '0x0');

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -473,6 +473,12 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
   callback(null, this.state.blockchain.increaseTime(seconds));
 };
 
+GethApiDouble.prototype.evm_skipBlocks = function(numBlocks, callback) {
+  this.state.skipBlocks(numBlocks, function(err) {
+    callback(err, '0x0');
+  });
+};
+
 GethApiDouble.prototype.evm_mineBlocks = function(numBlocks, callback) {
   let n = numBlocks;
   if (typeof n == "function" && callback == undefined) {
@@ -488,6 +494,10 @@ GethApiDouble.prototype.evm_mine = function(callback) {
   this.state.processBlocks(1, function(err) {
     callback(err, '0x0');
   });
+};
+
+GethApiDouble.prototype.evm_getLogsWithFakeBlocks = function(filter, callback) {
+  this.state.getLogsWithFakeBlocks(filter, callback);
 };
 
 GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callback) {

--- a/test/mining.js
+++ b/test/mining.js
@@ -119,6 +119,21 @@ describe("Mining", function() {
     });
   }
 
+  function mineMultipleBlocks(numBlocks) {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.send({
+        jsonrpc: "2.0",
+        method: "evm_mineBlocks",
+        params: [numBlocks],
+        id: new Date().getTime()
+      }, function(err, result) {
+        if (err) return reject(err);
+        assert.deepEqual(result.result, "0x0");
+        accept(result);
+      })
+    });
+  }
+
   function queueTransaction(from, to, gasLimit, value, data) {
     return new Promise(function(accept, reject) {
       web3.eth.sendTransaction({
@@ -431,5 +446,14 @@ describe("Mining", function() {
     }).then(function(is_mining) {
       assert(is_mining);
     });
+  });
+
+  it("should mine multiple blocks", function() {
+    const numBlocks = 10;
+    return mineMultipleBlocks(numBlocks).then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, numBlocks);
+    })
   });
 });

--- a/test/mining.js
+++ b/test/mining.js
@@ -134,6 +134,48 @@ describe("Mining", function() {
     });
   }
 
+  function getLogsWithFakeBlocks() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.send({
+        jsonrpc: "2.0",
+        method: "evm_getLogsWithFakeBlocks",
+        params: [{}],
+        id: new Date().getTime()
+      }, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      })
+    });
+  }
+
+  function getLogs() {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.send({
+        jsonrpc: "2.0",
+        method: "eth_getLogs",
+        params: [{}],
+        id: new Date().getTime()
+      }, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      })
+    });
+  }
+
+  function skipBlocks(numBlocks) {
+    return new Promise(function(accept, reject) {
+      web3.currentProvider.send({
+        jsonrpc: "2.0",
+        method: "evm_skipBlocks",
+        params: [numBlocks],
+        id: new Date().getTime()
+      }, function(err, result) {
+        if (err) return reject(err);
+        accept(result);
+      })
+    });
+  }
+
   function queueTransaction(from, to, gasLimit, value, data) {
     return new Promise(function(accept, reject) {
       web3.eth.sendTransaction({
@@ -455,5 +497,14 @@ describe("Mining", function() {
     }).then(function(number) {
       assert.equal(number, numBlocks);
     })
+  });
+
+  it("should skip multiple blocks", function() {
+    const numBlocks = 1000;
+    return skipBlocks(numBlocks).then(function() {
+      return getBlockNumber();
+    }).then(function(number) {
+      assert.equal(number, numBlocks);
+    });
   });
 });


### PR DESCRIPTION
I made two methods:

- `evm_mineBlocks:` - Mines multiple blocks. Accepts one arguments: number of blocks to mine.

- `evm_skipBlocks:` Will create one block with fake block number. Takes one argument: number of blocks you want to add on top of current block height. Useful when testing big block-number based constraints (eg. it would take ~1h to mine 500k blocks). It is not guaranteed that everything will this function, so you should save a snapshot of the blockchain before calling this function, then revert afterwards. Should be mainly used for checking block-number based constraints.