### PR TITLE
Update blockchain_double.js to properly hex encode Log without leading zeroes 

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -573,8 +573,8 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
           var data = to.hex(log[2]);
 
           var log = new Log({
-            logIndex: to.hex(i),
-            transactionIndex: to.hex(v),
+            logIndex: to.rpcQuantityHexString(i),
+            transactionIndex: to.rpcQuantityHexString(v),
             transactionHash: tx_hash,
             block: block,
             address: address,

--- a/lib/utils/txhelper.js
+++ b/lib/utils/txhelper.js
@@ -13,17 +13,17 @@ module.exports = {
       }
     }
     var resultJSON = {
-      hash: to.hex(tx.hash()),
-      nonce: to.hex(tx.nonce),
-      blockHash: to.hex(block.hash()),
-      blockNumber: to.hex(block.header.number),
-      transactionIndex: to.hex(transactionIndex),
-      from: to.hex(tx.from),
-      to: to.hex(tx.to),
-      value: to.hex(tx.value),
-      gas: to.hex(tx.gasLimit),
-      gasPrice: to.hex(tx.gasPrice),
-      input: to.hex(tx.data),
+      hash: to.rpcDataHexString(tx.hash()),
+      nonce: to.rpcDataHexString(tx.nonce),
+      blockHash: to.rpcDataHexString(block.hash()),
+      blockNumber: to.rpcQuantityHexString(block.header.number),
+      transactionIndex: to.rpcQuantityHexString(transactionIndex),
+      from: to.rpcDataHexString(tx.from),
+      to: to.rpcDataHexString(tx.to),
+      value: to.rpcQuantityHexString(tx.value),
+      gas: to.rpcQuantityHexString(tx.gasLimit),
+      gasPrice: to.rpcQuantityHexString(tx.gasPrice),
+      input: to.rpcDataHexString(tx.data),
     };
 
     if (tx.v && tx.v.length > 0 &&

--- a/lib/utils/txhelper.js
+++ b/lib/utils/txhelper.js
@@ -14,7 +14,7 @@ module.exports = {
     }
     var resultJSON = {
       hash: to.rpcDataHexString(tx.hash()),
-      nonce: to.rpcDataHexString(tx.nonce),
+      nonce: to.rpcQuantityHexString(tx.nonce),
       blockHash: to.rpcDataHexString(block.hash()),
       blockNumber: to.rpcQuantityHexString(block.header.number),
       transactionIndex: to.rpcQuantityHexString(transactionIndex),


### PR DESCRIPTION
When trying to talk to `ganache-cli` overRPC from go-ethereum: `cannot unmarshal hex number with leading zero digits into Go struct field Log.logIndex of type hexutil.Uint`

This was based off of changes I observed in #92