### PR TITLE
There is no need to check if the recipient of a transaction is a contract or not

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -810,28 +810,9 @@ StateManager.prototype.createFakeTransactionWithCorrectNonce = function(rawTx, f
       }
     }
 
-    // If we're calling a contract, check to make sure the address specified is a contract address
-    if (_transactionIsContractCall(rawTx)) {
-      self.getCode(to.hex(rawTx.to), 'latest', function(err, code) {
-        if (err) {
-          callback(err);
-        } else if (code === '0x0') {
-          callback(new TXRejectedError(`Attempting to run transaction which calls a contract function, but recipient address ${to.hex(rawTx.to)} is not a contract address`))
-        } else {
-          callback(null, tx)
-        }
-      });
-    } else {
-      callback(null, tx)
-    }
+    callback(null, tx)
+
   });
 }
 
-// returns true when transaction has a non-null, non-empty to and data field
-var _transactionIsContractCall = function(rawTx) {
-  let recipient = to.hex(rawTx.to || '0x0')
-  let data = to.hex(rawTx.data || '0x0')
-
-  return recipient !== '0x0' && data !== '0x0'
-}
 module.exports = StateManager;


### PR DESCRIPTION
Everytime ganache sees a "data" field, it assumes that it is trying to call a contract function and that the "to" field must be a contract. This should not be the case.

It should be perfectly fine to do this:

```
web3.eth.sendTransaction({from:web3.eth.accounts[0],to:web3.eth.accounts[1],value:web3.toWei(0.02,“ether”),data:web3.toHex(“hellow world”)})
```

This above snippet below is working in testnet but not in ganache.