### PR TITLE
gasPrice should be encoded as rpc quantity hex

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -57,7 +57,7 @@ StateManager = function(options, provider) {
   this.wallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(this.mnemonic));
   this.wallet_hdpath = options.hdPath;
 
-  this.gasPriceVal = to.hex(options.gasPrice);
+  this.gasPriceVal = to.rpcQuantityHexString(options.gasPrice);
 
   this.is_mining = true;
   this.blockTime = options.blockTime;


### PR DESCRIPTION
go-ethereum code errors as follows when deserializing `eth_gasPrice` response:

`failed to suggest gas price: json: cannot unmarshal hex number with leading zero digits into Go value of type *hexutil.Big`