### PR TITLE
Flush VM Cache Before Pushing Contract Code

### DIFF
--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -305,22 +305,24 @@ ForkedBlockchain.prototype.putCode = function(address, value, callback) {
   // we can't just be satisfied putting it in the cache.
 
   var self = this;
-  address = utils.toBuffer(address);
-  this.stateTrie.get(address, function(err, data) {
-    if (err) return callback(err);
-
-    var account = new Account(data);
-    account.setCode(self.stateTrie, value, function(err, result) {
+  self.vm.stateManager.cache.flush(function() => {
+    address = utils.toBuffer(address);
+    this.stateTrie.get(address, function(err, data) {
       if (err) return callback(err);
 
-      self.stateTrie.put(address, account.serialize(), function(err) {
+      var account = new Account(data);
+      account.setCode(self.stateTrie, value, function(err, result) {
         if (err) return callback(err);
 
-        // Ensure the cache updates as well.
-        self.vm.stateManager.putAccount(address, account, callback);
+        self.stateTrie.put(address, account.serialize(), function(err) {
+          if (err) return callback(err);
+
+          // Ensure the cache updates as well.
+          self.vm.stateManager.putAccount(address, account, callback);
+        });
       });
-    });
-  })
+    })
+  });
 };
 
 ForkedBlockchain.prototype.getAccount = function(address, number, callback) {

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -305,7 +305,7 @@ ForkedBlockchain.prototype.putCode = function(address, value, callback) {
   // we can't just be satisfied putting it in the cache.
 
   var self = this;
-  self.vm.stateManager.cache.flush(function() => {
+  self.vm.stateManager.cache.flush(function() {
     address = utils.toBuffer(address);
     this.stateTrie.get(address, function(err, data) {
       if (err) return callback(err);

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -305,7 +305,7 @@ ForkedBlockchain.prototype.putCode = function(address, value, callback) {
   // we can't just be satisfied putting it in the cache.
 
   var self = this;
-  self.vm.stateManager.cache.flush(function() {
+  self.vm.stateManager.cache.flush(() => {
     address = utils.toBuffer(address);
     this.stateTrie.get(address, function(err, data) {
       if (err) return callback(err);

--- a/test/forking_deploy_after_fork.js
+++ b/test/forking_deploy_after_fork.js
@@ -1,6 +1,5 @@
 var Web3 = require('web3');
 var Web3WsProvider = require('web3-providers-ws');
-var utils = require('ethereumjs-util');
 var assert = require('assert');
 var Ganache = require("../index.js");
 var fs = require("fs");
@@ -29,15 +28,11 @@ describe("Contract Deployed on Main Chain After Fork", function() {
   var contractAddress;
   var forkedServer;
   var mainAccounts;
-  var forkedAccounts;
 
   var forkedWeb3 = new Web3();
   var mainWeb3 = new Web3();
 
   var forkedTargetUrl = "ws://localhost:21345";
-  var forkBlockNumber;
-
-  var initialDeployTransactionHash;
 
   before("set up test data", function() {
     this.timeout(10000)
@@ -83,21 +78,11 @@ describe("Contract Deployed on Main Chain After Fork", function() {
     });
   });
 
-  before("set forkedWeb3 provider", function(done) {
+  before("set forkedWeb3 provider", function() {
     forkedWeb3.setProvider(new Web3WsProvider(forkedTargetUrl));
-    done();
   });
 
-  before("Gather forked accounts", function(done) {
-    this.timeout(5000)
-    forkedWeb3.eth.getAccounts(function(err, f) {
-      if (err) return done(err);
-      forkedAccounts = f;
-      done();
-    });
-  });
-
-  before("Set main web3 provider, forking from forked chain at this point", function(done) {
+  before("Set main web3 provider, forking from forked chain at this point", function() {
     mainWeb3.setProvider(Ganache.provider({
       fork: forkedTargetUrl.replace('ws', 'http'),
       logger,
@@ -106,62 +91,35 @@ describe("Contract Deployed on Main Chain After Fork", function() {
       // Do not change seed. Determinism matters for these tests.
       seed: "a different seed"
     }));
-
-    forkedWeb3.eth.getBlockNumber(function(err, number) {
-      if (err) return done(err);
-      forkBlockNumber = number;
-      done();
-    });
   });
 
-  before("Gather main accounts", function(done) {
+  before("Gather main accounts", async function() {
     this.timeout(5000)
-    mainWeb3.eth.getAccounts(function(err, m) {
-      if (err) return done(err);
-      mainAccounts = m;
-      done();
-    });
+    mainAccounts = await mainWeb3.eth.getAccounts();
   });
 
-  before("Deploy initial contract", function(done) {
-    mainWeb3.eth.sendTransaction({
+  before("Deploy initial contract", async function() {
+    const receipt = await mainWeb3.eth.sendTransaction({
       from: mainAccounts[0],
       data: contract.binary,
       gas: 3141592,
       value: mainWeb3.utils.toWei('1', 'ether')
-    }, function(err, tx) {
-      if (err) { return done(err); }
-
-      // Save this for a later test.
-      initialDeployTransactionHash = tx;
-
-      mainWeb3.eth.getTransactionReceipt(tx, function(err, receipt) {
-        if (err) return done(err);
-
-        contractAddress = receipt.contractAddress;
-
-        mainWeb3.eth.getCode(contractAddress, function(err, code) {
-          if (err) return done(err);
-
-          // Ensure there's *something* there.
-          assert.notEqual(code, null);
-          assert.notEqual(code, "0x");
-          assert.notEqual(code, "0x0");
-
-          done();
-        })
-      });
     });
+
+    contractAddress = receipt.contractAddress;
+
+    // Ensure there's *something* there.
+    const code = await mainWeb3.eth.getCode(contractAddress);
+    assert.notEqual(code, null);
+    assert.notEqual(code, "0x");
+    assert.notEqual(code, "0x0");
   });
 
-  it("should send 1 ether to the created contract, checked on the forked chain", function(done) {
-    mainWeb3.eth.getBalance(contractAddress, function(err, balance) {
-      if (err) return done(err);
+  it("should send 1 ether to the created contract, checked on the forked chain", async function() {
+    const balance = await mainWeb3.eth.getBalance(contractAddress);
 
-      assert.equal(balance, mainWeb3.utils.toWei('1', 'ether'));
-      done();
-    })
-  });
+    assert.equal(balance, mainWeb3.utils.toWei('1', 'ether'));
+  })
 
   after("Shutdown server", function(done) {
     forkedWeb3._provider.connection.close()


### PR DESCRIPTION
In our monkey-patching/duck-punching function for putContractCode, we pull the account from the state trie to put the code. However, putContractCode is called before the cache will be flushed, causing any balance in the account to be lost.

This PR flushes the VM cache before getting the account details.

This addresses #124 and should be merged in after #124.