### PR TITLE
Convert bignumbers properly for forked fallback balance lookup

### DIFF
--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -10,6 +10,7 @@ var Web3 = require("web3");
 var to = require("./to.js");
 var async = require("async");
 var txhelper = require("./txhelper.js")
+var BN  = require("bn.js");
 
 var inherits = require("util").inherits;
 
@@ -467,7 +468,7 @@ ForkedBlockchain.prototype.fetchBalanceFromFallback = function(address, block_nu
     self.web3.eth.getBalance(address, safe_block_number, function(err, balance) {
       if (err) return callback(err);
 
-      balance = "0x" + balance.toString(16); // BigNumber
+      balance = "0x" + new BN(balance).toString(16);
       callback(null, balance);
     });
   });

--- a/test/forking.js
+++ b/test/forking.js
@@ -509,10 +509,20 @@ describe("Forking", function() {
       // are hard to assert in this case.
       assert(balanceBeforeFork.gt(balanceAfterFork));
 
+      // Make sure it's not substantially larger. it should only be larger by a small
+      // amount (<2%). This assertion was added since forked balances were previously
+      // incorrectly being converted between decimal and hex
+      assert(balanceBeforeFork.muln(0.95).lt(balanceAfterFork));
+
       // Since the forked provider had once extra transaction for this account,
       // it should have a lower balance, and the main provider shouldn't acknowledge
       // that transaction.
       assert(balanceLatestMain.gt(balanceLatestFallback));
+
+      // Make sure it's not substantially larger. it should only be larger by a small
+      // amount (<2%). This assertion was added since forked balances were previously
+      // incorrectly being converted between decimal and hex
+      assert(balanceLatestMain.muln(0.95).lt(balanceLatestFallback));
 
       done();
     });


### PR DESCRIPTION
This PR fixes an issue with a change in how the balances were provided from web3. I believe that the original implementation was referencing https://github.com/ethereum/wiki/wiki/JavaScript-API#returns-33 instead of the newer version: https://web3js.readthedocs.io/en/1.0/web3-eth.html#getbalance

This PR also updates the test which checks the balance difference between forked chain and base chain. It tests to make sure the values are ~5% near each other. I think there is a better way to test this by creating a new test which doesn't have transactions and merely just checks the balance. This fix will address the problem for now however.


Fixes #128