### PR TITLE
eth_getLogs should accept address as DATA|Array per https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getlogs

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -643,7 +643,7 @@ StateManager.prototype.getBlock = function(hash_or_number, callback) {
 StateManager.prototype.getLogs = function(filter, callback) {
   var self = this;
 
-  var expectedAddress = filter.address;
+  var expectedAddress = (!Array.isArray(filter.address) && !!filter.address ? [filter.address] : filter.address || []).map(x => x.toLowerCase());
   var expectedTopics = filter.topics || [];
 
   async.parallel({
@@ -670,7 +670,7 @@ StateManager.prototype.getLogs = function(filter, callback) {
 
         // Filter logs that match the address
         var filtered = blockLogs.filter(function(log) {
-          return (expectedAddress == null || log.address.toLowerCase() == expectedAddress.toLowerCase());
+          return expectedAddress.includes(log.address.toLowerCase());
         });
 
         // Now filter based on topics.


### PR DESCRIPTION
Most recent push https://github.com/trufflesuite/ganache-core/commit/81b11c4833b2377a3b4d6ce527e2452b80f9bcc3 is broken with array input

Previous code was broken for arrays with length > 1 or casing issues