### PR TITLE
Stop the engine when we stop the provider. fix a bug caused by it

### DIFF
--- a/lib/block_tracker.js
+++ b/lib/block_tracker.js
@@ -46,7 +46,7 @@ GanacheBlockTracker.prototype.start = function(opts = {}) {
 
 GanacheBlockTracker.prototype.stop = function() {
   this._isRunning = false
-  this._blockchain.removeListener(_setCurrentBlock)
+  this._blockchain.removeListener('block', this._setCurrentBlock)
 }
 
   //

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -117,6 +117,7 @@ Provider.prototype.send = function(payload, callback) {
 Provider.prototype.close = function(callback) {
   // This is a little gross reaching, but...
   this.manager.state.blockchain.close(callback);
+  this.engine.stop()
 };
 
 Provider.prototype._queueRequest = function(payload, intermediary) {


### PR DESCRIPTION
Add logic to stop the engine when we stop the provider to make sure things close smoothly. This surfaced a bug in the GanacheBlockTracker which was then fixed