### PR TITLE
Add User-Agent token to allowed headers

### DIFF
--- a/lib/httpServer.js
+++ b/lib/httpServer.js
@@ -62,7 +62,7 @@ module.exports = function (provider, logger) {
           break;
         default:
           response.writeHead(400, {
-            "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept",
+            "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "*",
             "Content-Type": "text/plain"

--- a/lib/httpServer.js
+++ b/lib/httpServer.js
@@ -18,7 +18,7 @@ module.exports = function (provider, logger) {
       // do whatever we need to in order to respond to this request.
 
       var headers = {
-        "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept",
+        "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept, User-Agent",
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "*"
       };


### PR DESCRIPTION
Related: https://github.com/ethereum/web3.js/issues/1803

Also related: https://github.com/trufflesuite/ganache/issues/359

Although the latter is a broader issue, I fixed my immediate problem of not being able to connect from Firefox. I will look into the rest in a separate branch as requested by @davidmurdoch 