### PR TITLE
Fix race conditions causing problems identified in #417

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TODO
 .tern-port
 .vscode
 yarn.lock
+*.swp

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -54,6 +54,18 @@ BlockchainDouble.prototype._applyDefaultOptions = function(options) {
   return _.merge(options, defaultOptions, Object.assign({}, options));
 }
 
+BlockchainDouble.prototype._stateCheckpoint = function() {
+  this.vm.stateManager.checkpoint();
+}
+
+BlockchainDouble.prototype._stateCommit = function(callback) {
+  this.vm.stateManager.commit(callback);
+}
+
+BlockchainDouble.prototype._stateRevert = function(callback) {
+  this.vm.stateManager.revert(callback);
+}
+
 BlockchainDouble.prototype.initialize = function(accounts, callback) {
   var self = this;
 
@@ -437,7 +449,7 @@ BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
   var startingStateRoot;
 
   var cleanUpAndReturn = function (err, result, changeRoot) {
-    self.vm.stateManager.revert(function (e) {
+    self._stateRevert(function (e) {
       // For defaultBlock, undo state root changes
       if (changeRoot){
         self.stateTrie.root = startingStateRoot;
@@ -461,7 +473,7 @@ BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
 
       // We checkpoint here for speed. We want all state trie reads/writes to happen in memory,
       // and the final output be flushed to the database at the end of transaction processing.
-      self.vm.stateManager.checkpoint();
+      self._stateCheckpoint()
 
       var runArgs = {
         tx: tx,
@@ -515,10 +527,10 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
 
   // We checkpoint here for speed. We want all state trie reads/writes to happen in memory,
   // and the final output be flushed to the database at the end of transaction processing.
-  self.vm.stateManager.checkpoint();
+  self._stateCheckpoint()
 
   var cleanup = function(err) {
-    self.vm.stateManager.revert(function(e) {
+    self._stateRevert(function(e) {
       callback(err || e);
     });
   };
@@ -593,14 +605,14 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
 
     function commmitIfNeeded(cb) {
       if (commit === true) {
-        self.vm.stateManager.commit(function(e) {
+        self._stateCommit(function(e) {
           if (e) return cleanup(e);
 
           // Put that block on the end the chain
           self.putBlock(block, logs, receipts, cb);
         });
       } else {
-        self.vm.stateManager.revert(cb);
+        self._stateRevert(cb);
       }
     }
 

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -1,4 +1,5 @@
 var to = require("./utils/to.js");
+const semaphore = require('semaphore');
 var Account = require('ethereumjs-account');
 var Block = require('ethereumjs-block');
 var Log = require("./utils/log");
@@ -55,19 +56,37 @@ BlockchainDouble.prototype._applyDefaultOptions = function(options) {
 }
 
 BlockchainDouble.prototype._stateCheckpoint = function() {
-  this.vm.stateManager.checkpoint();
+  var self = this;
+  self.semForStateTrie.take(function() {
+    self.vm.stateManager.checkpoint();
+  });
 }
 
 BlockchainDouble.prototype._stateCommit = function(callback) {
-  this.vm.stateManager.commit(callback);
+  var self = this;
+  self.vm.stateManager.commit(function(e) {
+    if (!e) {
+      self.semForStateTrie.leave();
+    }
+    callback(e);
+  });
 }
 
 BlockchainDouble.prototype._stateRevert = function(callback) {
-  this.vm.stateManager.revert(callback);
+  var self = this;
+  self.vm.stateManager.revert(function(e) {
+    if (!e) {
+      self.semForStateTrie.leave();
+    }
+    callback(e);
+  });
 }
 
 BlockchainDouble.prototype.initialize = function(accounts, callback) {
   var self = this;
+
+  // Used to prevent race conditions on stateTrie
+  this.semForStateTrie = semaphore(1);
 
   this.data.initialize(function(err) {
     if (err) return callback(err);
@@ -473,7 +492,7 @@ BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
 
       // We checkpoint here for speed. We want all state trie reads/writes to happen in memory,
       // and the final output be flushed to the database at the end of transaction processing.
-      self._stateCheckpoint()
+      self._stateCheckpoint();
 
       var runArgs = {
         tx: tx,
@@ -527,7 +546,7 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
 
   // We checkpoint here for speed. We want all state trie reads/writes to happen in memory,
   // and the final output be flushed to the database at the end of transaction processing.
-  self._stateCheckpoint()
+  self._stateCheckpoint();
 
   var cleanup = function(err) {
     self._stateRevert(function(e) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepend-file": "^1.3.1",
     "request": "^2.87.0",
     "seedrandom": "~2.4.2",
+    "semaphore": "~1.1.0",
     "shebang-loader": "0.0.1",
     "solc": "0.4.24",
     "temp": "^0.8.3",

--- a/test/stability.js
+++ b/test/stability.js
@@ -131,8 +131,7 @@ describe("stability", function(done) {
     });// nothing to check from here, if the promise rejects, test fails
   })
 
-  //TODO: remove `.skip` when working on and/or submitting fix for issue #453
-  describe.skip("race conditions", function(done) {
+  describe("race conditions", function(done) {
     var web3 = new Web3();
     var provider;
     var accounts;
@@ -158,9 +157,9 @@ describe("stability", function(done) {
       });
 
       var blockchain = provider.manager.state.blockchain;
-      blockchain.vm.stateManager.checkpoint(); // processCall or processBlock
+      blockchain._stateCheckpoint(); // processCall or processBlock
       blockchain.stateTrie.get(utils.toBuffer(accounts[0]), function() {}); // getCode (or any function that calls trie.get)
-      blockchain.vm.stateManager.revert(function() {
+      blockchain._stateRevert(function() {
         done();
       }); // processCall or processBlock
     });
@@ -171,11 +170,11 @@ describe("stability", function(done) {
       });
 
       var blockchain = provider.manager.state.blockchain;
-      blockchain.vm.stateManager.checkpoint(); // processCall #1
+      blockchain._stateCheckpoint(); // processCall #1
       // processNextBlock triggered by interval mining which at some point calls vm.stateManager.commit() and blockchain.putBlock()
       blockchain.processNextBlock(function(err, tx, results) {
-        blockchain.vm.stateManager.revert(function() { // processCall #1 finishes
-          blockchain.latestBlock(function (err, latestBlock) { 
+        blockchain._stateRevert(function() { // processCall #1 finishes
+          blockchain.latestBlock(function (err, latestBlock) {
             blockchain.stateTrie.root = latestBlock.header.stateRoot; // getCode #1 (or any function with this logic)
             web3.eth.call({}, function() {
               done();


### PR DESCRIPTION
This PR fixes the problem described in [here](https://github.com/trufflesuite/ganache-cli/issues/453).

**Problem:**
The root cause of the problem is that we use `blockchain.vm.stateManager.[checkpoint|commit|revert]()` assuming there is no other functions performing transactions (meaning db transaction instead  of blockchain transaction :)) on `stateTrie`. Doing this without a lock can cause race conditions. For example, the following events can cause race conditions:
1. `checkpoint()` is called by `processCall()`
1. `checkpoint()` is called by `processNextBlock()`
1. `revert()` is called by `processCall()` <- this reverts the checkpoint created by `processNextBlock()`
1. `commit()` is called by `processNextBlock()` <- this commits the checkpoint created by `processCall()`

**Solution:**
This PR solves this problem by introducing a semaphore lock on the stateTrie transactions to prevent functions unintentionally committing or reverting a checkpoint created by other functions.