### PR TITLE
[FIX] Refine isContract call to support Present design

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -883,15 +883,20 @@ StateManager.prototype.createFakeTransactionWithCorrectNonce = function(rawTx, f
 
     // If we're calling a contract, check to make sure the address specified is a contract address
     if (_transactionIsContractCall(rawTx)) {
-      self.getCode(to.hex(rawTx.to), 'latest', function(err, code) {
-        if (err) {
-          callback(err);
-        } else if (code === '0x0') {
-          callback(new TXRejectedError(`Attempting to run transaction which calls a contract function, but recipient address ${to.hex(rawTx.to)} is not a contract address`))
-        } else {
-          callback(null, tx)
-        }
-      });
+      // Contract just being deployed, code yet to exist at adress
+      if (!rawTx.to || rawTx.to === '0x0' || rawTx.to === '0x' || rawTx.to === '0') {
+        callback(null, tx)
+      } else {
+        self.getCode(to.hex(rawTx.to), 'latest', function(err, code) {
+          if (err) {
+            callback(err);
+          } else if (code === '0x0') {
+            callback(new TXRejectedError(`Attempting to run transaction which calls a contract function, but recipient address ${to.hex(rawTx.to)} is not a contract address`))
+          } else {
+            callback(null, tx)
+          }
+        });
+      }
     } else {
       callback(null, tx)
     }
@@ -903,6 +908,6 @@ var _transactionIsContractCall = function(rawTx) {
   let recipient = to.hex(rawTx.to || '0x0')
   let data = to.hex(rawTx.data || '0x0')
 
-  return recipient !== '0x0' && data !== '0x0'
+  return recipient === '0x0' || recipient === '0x' || recipient === '0' || data !== '0x0'
 }
 module.exports = StateManager;


### PR DESCRIPTION
Fixes #117 
@bernardpeh created #119 which completely removes the contract call check, which was closed as tests were not passing.
This handles the possible scenarios under which it is a contract call and only checks for for code presence if it should already exist.