### PR TITLE
`eth_getCompilers` should return an empty array since we don't allow compilation

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -360,7 +360,7 @@ GethApiDouble.prototype.shh_version = function(callback) {
 };
 
 GethApiDouble.prototype.eth_getCompilers = function(callback) {
-  callback(null, ["solidity"]);
+  callback(null, []);
 }
 
 GethApiDouble.prototype.eth_syncing = function(callback) {

--- a/test/requests.js
+++ b/test/requests.js
@@ -77,6 +77,16 @@ var tests = function(web3) {
     });
   });
 
+  describe("eth_getCompilers", function() {
+    it.only("should return an empty array", function() {
+      return web3.eth.getCompilers()
+        .then(function(compilers) {
+          assert(Array.isArray(compilers));
+          assert.equal(0, compilers.length);
+        })
+    });
+  });
+
   describe("eth_blockNumber", function() {
     it("should return initial block number of zero", function(done) {
       var number = web3.eth.getBlockNumber(function(err, result) {


### PR DESCRIPTION
With a test :-p

Fixes #139