### PR TITLE
Additional fix to #51 (eth_getCode on a non-contract should return 0x)

### DIFF
--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -4,9 +4,7 @@ module.exports = {
   // Note: Do not use to.hex() when you really mean utils.addHexPrefix().
   hex: function(val) {
     if (typeof val == "string") {
-      if (val === "0x") {
-        return "0x0";
-      } else if (val.indexOf("0x") == 0) {
+      if (val.indexOf("0x") == 0) {
         return val;
       } else {
         val = new utils.BN(val);

--- a/lib/utils/to.js
+++ b/lib/utils/to.js
@@ -25,10 +25,6 @@ module.exports = {
     // Hint: BN is used in ethereumjs
     if (typeof val == "object") {
       val = val.toString("hex");
-
-      if (val == "") {
-        val = "0";
-      }
     }
 
     return utils.addHexPrefix(val);

--- a/test/block_tags.js
+++ b/test/block_tags.js
@@ -127,12 +127,12 @@ describe("Block Tags", function() {
   it("should return the no code at the previous block number", function(done) {
     web3.eth.getCode(contractAddress, initial_block_number, function(err, code) {
       if (err) return done(err);
-      assert.equal(code, "0x0");
+      assert.equal(code, "0x");
 
       // Check that the code incremented with the block number, just to be sure.
       web3.eth.getCode(contractAddress, initial_block_number + 1, function(err, code) {
         if (err) return done(err);
-        assert.notEqual(code, "0x0");
+        assert.notEqual(code, "0x");
         assert(code.length > 20); // Just because we don't know the actual code we're supposed to get back
         done();
       });

--- a/test/hex.js
+++ b/test/hex.js
@@ -127,3 +127,10 @@ describe("JSON-RPC Response", function() {
     });
   });
 });
+
+describe("to.hex", function() {
+  it("should print '0x' for input '' (blank)", function(done) {
+    assert.equal(to.hex(Buffer("")), "0x");
+    done();
+  });
+})

--- a/test/interval_mining.js
+++ b/test/interval_mining.js
@@ -142,7 +142,7 @@ describe("Interval Mining", function() {
     });
   });
 
-  it("should log runtime errors to the log", function(done) {
+  it("should log runtime errors to the log", async function() {
     this.timeout(5000);
 
     var logData = "";
@@ -161,20 +161,16 @@ describe("Interval Mining", function() {
     var result = solc.compile({sources: {"Example.sol": "pragma solidity ^0.4.2; contract Example { function Example() {throw;} }"}}, 1);
     var bytecode = "0x" + result.contracts["Example.sol:Example"].bytecode;
 
-    web3.eth.sendTransaction({
-      from: first_address,
-      data: bytecode,
-      gas: 3141592
-    }, function(err, tx) {
-      if (err) return done(err);
-
-      // Wait .75 seconds (one and a half mining intervals) and ensure log sees error.
-      setTimeout(function() {
-        assert(logData.indexOf("Runtime Error: revert") >= 0);
-        done();
-      }, 750);
-    });
-
+    try {
+      let receipt = await web3.eth.sendTransaction({
+        from: first_address,
+        data: bytecode,
+        gas: 3141592
+      });
+      assert.fail("Contract deploy promise should have rejected");
+    } catch (e) {
+      assert(logData.indexOf("Runtime Error: revert") >= 0);
+    }
   });
 
 });

--- a/test/mining.js
+++ b/test/mining.js
@@ -4,6 +4,7 @@ var Ganache = require(process.env.TEST_BUILD ? "../build/ganache.core." + proces
 var assert = require('assert');
 var to = require("../lib/utils/to.js");
 var solc = require("solc");
+var pify = require("pify");
 
 // Thanks solc. At least this works!
 // This removes solc's overzealous uncaughtException event handler.
@@ -19,417 +20,318 @@ describe("Mining", function() {
   var badBytecode;
   var goodBytecode;
 
-  before("compile solidity code that causes runtime errors", function() {
+  before("compile solidity code that causes runtime errors", async function() {
     this.timeout(10000)
-    return compileSolidity("pragma solidity ^0.4.2; contract Example { function Example() {throw;} }").then(function(result) {
-      badBytecode = result.code;
-    });
+    let result = await compileSolidity("pragma solidity ^0.4.2; contract Example { function Example() {throw;} }");
+    badBytecode = result.code;
   });
 
-  before("compile solidity code that causes an event", function() {
+  before("compile solidity code that causes an event", async function() {
     this.timeout(10000)
-    return compileSolidity("pragma solidity ^0.4.2; contract Example { event Event(); function Example() { Event(); } }").then(function(result) {
-      goodBytecode = result.code;
-    });
+    let result = await compileSolidity("pragma solidity ^0.4.2; contract Example { event Event(); function Example() { Event(); } }");
+    goodBytecode = result.code;
   });
 
-  beforeEach("checkpoint, so that we can revert later", function(done) {
-    web3.currentProvider.send({
+  beforeEach("checkpoint, so that we can revert later", async function() {
+    let res = await pify(web3.currentProvider.send)({
       jsonrpc: "2.0",
       method: "evm_snapshot",
       id: new Date().getTime()
-    }, function(err, res) {
-      if (!err) {
-        snapshot_id = res.result;
-      }
-      done(err);
     });
+
+    snapshot_id = res.result;
   });
 
-  afterEach("revert back to checkpoint", function(done) {
-    web3.currentProvider.send({
+  afterEach("revert back to checkpoint", async function() {
+    await pify(web3.currentProvider.send)({
       jsonrpc: "2.0",
       method: "evm_revert",
       params: [snapshot_id],
       id: new Date().getTime()
-    }, done);
+    });
   });
 
   // Everything's a Promise to add in readibility.
-  function getBlockNumber() {
-    return new Promise(function(accept, reject) {
-      web3.eth.getBlockNumber(function(err, number) {
-        if (err) return reject(err);
-        accept(to.number(number));
-      });
-    });
+  async function getBlockNumber() {
+    return to.number(await web3.eth.getBlockNumber())
   };
 
-  function startMining() {
-    return new Promise(function(accept, reject) {
-      web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "miner_start",
-        params: [1],
-        id: new Date().getTime()
-      }, function(err) {
-        if (err) return reject(err);
-        accept();
-      });
+  async function startMining() {
+    await pify(web3.currentProvider.send)({
+      jsonrpc: "2.0",
+      method: "miner_start",
+      params: [1],
+      id: new Date().getTime()
     });
   }
 
-  function stopMining() {
-    return new Promise(function(accept, reject) {
-      web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "miner_stop",
-        id: new Date().getTime()
-      }, function(err) {
-        if (err) return reject(err);
-        accept();
-      });
+  async function stopMining() {
+    await pify(web3.currentProvider.send)({
+      jsonrpc: "2.0",
+      method: "miner_stop",
+      id: new Date().getTime()
     });
   }
 
-  function checkMining() {
-    return new Promise(function(accept, reject) {
-      web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "eth_mining",
-        id: new Date().getTime()
-      }, function(err, res) {
-        if (err) return reject(err);
-        accept(res.result);
-      });
+  async function checkMining() {
+    let response = await pify(web3.currentProvider.send)({
+      jsonrpc: "2.0",
+      method: "eth_mining",
+      id: new Date().getTime()
     });
+
+    return response.result;
   }
 
-  function mineSingleBlock() {
-    return new Promise(function(accept, reject) {
-      web3.currentProvider.send({
-        jsonrpc: "2.0",
-        method: "evm_mine",
-        id: new Date().getTime()
-      }, function(err, result) {
-        if (err) return reject(err);
-        assert.deepEqual(result.result, "0x0");
-        accept(result);
-      })
+  async function mineSingleBlock() {
+    let result = await pify(web3.currentProvider.send)({
+      jsonrpc: "2.0",
+      method: "evm_mine",
+      id: new Date().getTime()
     });
+    assert.deepEqual(result.result, "0x0");
   }
 
-  function queueTransaction(from, to, gasLimit, value, data) {
-    return new Promise(function(accept, reject) {
-      web3.eth.sendTransaction({
+  async function queueTransaction(from, to, gasLimit, value, data) {
+    let response = await pify(web3.currentProvider.send)({
+      jsonrpc: "2.0",
+      method: "eth_sendTransaction",
+      id: new Date().getTime(),
+      params: [{
         from: from,
         to: to,
         gas: gasLimit,
         value: value,
         data: data
-      }, function(err, tx) {
-        if (err) return reject(err);
-        accept(tx);
-      });
+      }]
     })
+    if (response.error) {
+      throw new Error(response.error.message)
+    }
+    return response.result
   }
 
-  function getReceipt(tx) {
-    return new Promise(function(accept, reject) {
-      web3.eth.getTransactionReceipt(tx, function(err, result) {
-        if (err) return reject(err);
-        accept(result);
-      });
-    });
-  };
-
-  function getCode(address) {
-    return new Promise(function(accept, reject) {
-      web3.eth.getCode(address, function(err, result) {
-        if (err) return reject(err);
-        accept(result);
-      });
-    });
+  async function getCode(address) {
+    return await web3.eth.getCode(address);
   };
 
   function compileSolidity(source) {
-    return new Promise(function(accept, reject) {
-      var result = solc.compile({sources: {"Contract.sol": source}});
-      accept({code: "0x" + result.contracts[Object.keys(result.contracts)[0]].bytecode})
-    });
+    let result = solc.compile({sources: {"Contract.sol": source}});
+    return Promise.resolve({code: "0x" + result.contracts[Object.keys(result.contracts)[0]].bytecode})
   };
 
-  before(function(done) {
-    web3.eth.getAccounts(function(err, accs) {
-      if (err) return done(err);
-      accounts = accs;
-      done();
-    });
+  before(async function() {
+    accounts = await web3.eth.getAccounts()
   });
 
-  it("should mine a single block with two queued transactions", function() {
-    var tx1, tx2, blockNumber;
+  it("should mine a single block with two queued transactions", async function() {
+    await stopMining()
+    let blockNumber = await getBlockNumber();
 
-    return stopMining().then(function() {
-      return getBlockNumber();
-    }).then(function(number) {
-      blockNumber = number;
-      return queueTransaction(accounts[0], accounts[1], 90000, web3.utils.toWei(new BN(2), "ether"));
-    }).then(function(tx) {
-      tx1 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    let tx1 = await queueTransaction(accounts[0], accounts[1], 90000, web3.utils.toWei(new BN(2), "ether"));
+    let receipt1 = await web3.eth.getTransactionReceipt(tx1);
+    assert.equal(receipt1, null);
 
-      return queueTransaction(accounts[0], accounts[1], 90000, web3.utils.toWei(new BN(3), "ether"));
-    }).then(function(tx) {
-      tx2 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    let tx2 = await queueTransaction(accounts[0], accounts[1], 90000, web3.utils.toWei(new BN(3), "ether"));
+    let receipt2 = await web3.eth.getTransactionReceipt(tx2);
+    assert.equal(receipt2, null);
 
-      return startMining();
-    }).then(function() {
-      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
-    }).then(function(receipts) {
-      assert.equal(receipts.length, 2);
-      assert.notEqual(receipts[0], null);
-      assert.equal(receipts[0].transactionHash, tx1);
-      assert.notEqual(receipts[1], null);
-      assert.equal(receipts[1].transactionHash, tx2);
-      assert.equal(receipts[0].blockNumber, receipts[1].blockNumber, "Transactions should be mined in the same block.");
+    await startMining();
 
-      return getBlockNumber();
-    }).then(function(number) {
-      assert.equal(number, blockNumber + 1);
-    });
+    let receipts = await Promise.all([web3.eth.getTransactionReceipt(tx1), web3.eth.getTransactionReceipt(tx2)]);
+
+    assert.equal(receipts.length, 2);
+
+    assert.notEqual(receipts[0], null);
+    assert.equal(receipts[0].transactionHash, tx1);
+    assert.notEqual(receipts[1], null);
+    assert.equal(receipts[1].transactionHash, tx2);
+    assert.equal(receipts[0].blockNumber, receipts[1].blockNumber, "Transactions should be mined in the same block.");
+
+    let number = await getBlockNumber();
+    assert.equal(number, blockNumber + 1);
   });
 
-  it("should mine two blocks when two queued transactions won't fit into a single block", function() {
+  it("should mine two blocks when two queued transactions won't fit into a single block", async function() {
     // This is a very similar test to the above, except the gas limits are much higher
     // per transaction. This means the Ganache will react differently and process
     // each transaction it its own block.
 
-    var tx1, tx2, blockNumber;
+    await stopMining();
+    let blockNumber = await getBlockNumber();
 
-    return stopMining().then(function() {
-      return getBlockNumber();
-    }).then(function(number) {
-      blockNumber = number;
-      return queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(2), "ether"));
-    }).then(function(tx) {
-      tx1 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    let tx1 = await queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(2), "ether"));
+    let receipt1 = await web3.eth.getTransactionReceipt(tx1);
+    assert.equal(receipt1, null);
 
-      return queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(3), "ether"));
-    }).then(function(tx) {
-      tx2 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    let tx2 = await queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(3), "ether"));
+    let receipt2 = await web3.eth.getTransactionReceipt(tx2);
+    assert.equal(receipt2, null);
 
-      return startMining();
-    }).then(function() {
-      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
-    }).then(function(receipts) {
-      assert.equal(receipts.length, 2);
-      assert.notEqual(receipts[0], null);
-      assert.equal(receipts[0].transactionHash, tx1);
-      assert.notEqual(receipts[1], null);
-      assert.equal(receipts[1].transactionHash, tx2);
-      assert.notEqual(receipts[0].blockNumber, receipts[1].blockNumber, "Transactions should not be mined in the same block.");
+    await startMining();
 
-      return getBlockNumber();
-    }).then(function(number) {
-      assert.equal(number, blockNumber + 2);
-    });
+    let receipts = await Promise.all([web3.eth.getTransactionReceipt(tx1), web3.eth.getTransactionReceipt(tx2)]);
+
+    assert.equal(receipts.length, 2);
+
+    assert.notEqual(receipts[0], null);
+    assert.equal(receipts[0].transactionHash, tx1);
+
+    assert.notEqual(receipts[1], null);
+    assert.equal(receipts[1].transactionHash, tx2);
+
+    assert.notEqual(receipts[0].blockNumber, receipts[1].blockNumber, "Transactions should not be mined in the same block.");
+
+    let number = await getBlockNumber();
+    assert.equal(number, blockNumber + 2);
   });
 
-  it("should mine one block when requested, and only one transaction, when two queued transactions together are larger than a single block", function() {
+  it("should mine one block when requested, and only one transaction, when two queued transactions together are larger than a single block", async function() {
     // This is a very similar test to the above, except we don't start mining again,
     // we only mine one block by request.
 
-    var tx1, tx2, blockNumber;
+    await stopMining()
+    let blockNumber = await getBlockNumber();
+    let tx1 = await queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(2), "ether"));
+    let receipt1 = await web3.eth.getTransactionReceipt(tx1);
+    assert.equal(receipt1, null);
 
-    return stopMining().then(function() {
-      return getBlockNumber();
-    }).then(function(number) {
-      blockNumber = number;
-      return queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(2), "ether"));
-    }).then(function(tx) {
-      tx1 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    let tx2 = await queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(3), "ether"));
+    let receipt2 = await web3.eth.getTransactionReceipt(tx2);
+    assert.equal(receipt2, null);
 
-      return queueTransaction(accounts[0], accounts[1], 4000000, web3.utils.toWei(new BN(3), "ether"));
-    }).then(function(tx) {
-      tx2 = tx;
-      return getReceipt(tx);
-    }).then(function(receipt) {
-      assert.equal(receipt, null);
+    await mineSingleBlock();
 
-      return mineSingleBlock();
-    }).then(function() {
-      return Promise.all([getReceipt(tx1), getReceipt(tx2)]);
-    }).then(function(receipts) {
-      assert.equal(receipts.length, 2);
-      assert.notEqual(receipts[0], null);
-      assert.equal(receipts[0].transactionHash, tx1);
-      assert.equal(receipts[1], null);
+    let receipts = await Promise.all([web3.eth.getTransactionReceipt(tx1), web3.eth.getTransactionReceipt(tx2)]);
 
-      return getBlockNumber();
-    }).then(function(number) {
-      assert.equal(number, blockNumber + 1);
-    });
+    assert.equal(receipts.length, 2);
+
+    assert.notEqual(receipts[0], null);
+    assert.equal(receipts[0].transactionHash, tx1);
+
+    assert.equal(receipts[1], null);
+
+    let number = await getBlockNumber();
+    assert.equal(number, blockNumber + 1);
   });
 
-  it("should error if queued transaction exceeds the block gas limit", function() {
-    return stopMining().then(function() {
-      return queueTransaction(accounts[0], accounts[1], 10000000, web3.utils.toWei(new BN(2), "ether"));
-    }).then(function(tx) {
-      // It should never get here.
-      throw new Error("Transaction was processed without erroring; gas limit should have been too high");
-    }).catch(function(err) {
+  it("should error if queued transaction exceeds the block gas limit", async function() {
+    try {
+      await stopMining()
+      let tx1 = await queueTransaction(accounts[0], accounts[1], 10000000, web3.utils.toWei(new BN(2), "ether"));
+      assert.fail("Transaction was processed without erroring; gas limit should have been too high");
+    } catch (err) {
       // We caught an error like we expected. Ensure it's the right error, or rethrow.
       if (err.message.toLowerCase().indexOf("exceeds block gas limit") < 0) {
-        throw new Error("Did not receive expected error; instead received: " + err);
+        assert.fail("Did not receive expected error; instead received: " + err);
       }
-    });
+    }
   });
 
-  it("should error via instamining when queued transaction throws a runtime errors", function(done) {
-    var tx1, tx2, blockNumber, bytecode, address;
-
-    startMining().then(function() {
+  it("should error via instamining when queued transaction throws a runtime errors", async function() {
+    try {
+      await startMining()
       // This transaction should be processed immediately.
-      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
-    }).then(function(tx) {
-      throw new Error("Execution should never get here as we expected `eth_sendTransaction` to throw an error")
-    }).catch(function(err) {
+      let tx1 = await queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+      assert.fail("Execution should never get here as we expected `eth_sendTransaction` to throw an error")
+    } catch (err) {
       if (err.message.indexOf("VM Exception while processing transaction") != 0) {
-        return done(new Error("Received error we didn't expect: " + err));
+        assert.fail("Received error we didn't expect: " + err);
       }
-      // We got the error we wanted. Test passed!
-      done();
-    });
+    }
   });
 
-  it("should error via evm_mine when queued transaction throws a runtime errors", function(done) {
-    var tx1, tx2, blockNumber, bytecode, address;
-
-    stopMining().then(function() {
-      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
-    }).then(function(tx) {
-      tx1 = tx;
-      return mineSingleBlock();
-    }).then(function() {
-      throw new Error("Execution should never get here as we expected `evm_mine` to throw an error")
-    }).catch(function(err) {
+  it("should error via evm_mine when queued transaction throws a runtime errors", async function() {
+    try {
+      await stopMining()
+      await queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+      await mineSingleBlock();
+      assert.fail("Execution should never get here as we expected `evm_mine` to throw an error")
+    } catch (err) {
       if (err.message.indexOf("VM Exception while processing transaction") != 0) {
-        return done(new Error("Received error we didn't expect: " + err));
+        assert.fail("Received error we didn't expect: " + err);
       }
-      // We got the error we wanted. Test passed!
-      done();
-    });
+    }
   });
 
-  it("should error via evm_mine when multiple queued transactions throw runtime errors in a single block", function(done) {
-    var tx1, tx2, blockNumber, bytecode;
-
+  it("should error via evm_mine when multiple queued transactions throw runtime errors in a single block", async function() {
     // Note: The two transactions queued in this test do not exceed the block gas limit
     // and thus should fit within a single block.
 
-    stopMining().then(function() {
-      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
-    }).then(function(tx) {
-      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
-    }).then(function(tx) {
-      return mineSingleBlock();
-    }).then(function() {
-      throw new Error("Execution should never get here as we expected `evm_mine` to throw an error")
-    }).catch(function(err) {
+    try {
+      await stopMining()
+      await queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+      await queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+      await mineSingleBlock();
+      assert.fail("Execution should never get here as we expected `evm_mine` to throw an error")
+    } catch (err) {
       if (err.message.indexOf("Multiple VM Exceptions while processing transactions") != 0) {
-        return done(new Error("Received error we didn't expect: " + err));
+        assert.fail("Received error we didn't expect: " + err);
       }
       // We got the error we wanted. Test passed!
-      done();
-    });
+    }
   });
 
-  it("should error via miner_start when multiple queued transactions throw runtime errors in multiple blocks", function(done) {
-    var blockNumber, bytecode;
-
+  it("should error via miner_start when multiple queued transactions throw runtime errors in multiple blocks", async function() {
     // Note: The two transactions queued in this test together DO exceed the block gas limit
     // and thus will fit in two blocks, one block each.
 
-    stopMining().then(function() {
-      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
-    }).then(function(tx) {
-      return queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
-    }).then(function(tx) {
-      return startMining();
-    }).then(function() {
-      throw new Error("Execution should never get here as we expected `miner_start` to throw an error")
-    }).catch(function(err) {
+    try { 
+      await stopMining()
+      await queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+      await queueTransaction(accounts[0], null, 3141592, 0, badBytecode);
+      await startMining();
+      assert.fail("Execution should never get here as we expected `miner_start` to throw an error")
+    } catch (err) {
       if (err.message.indexOf("Multiple VM Exceptions while processing transactions") != 0) {
-        return done(new Error("Received error we didn't expect: " + err));
+        assert.fail("Received error we didn't expect: " + err);
       }
       // We got the error we wanted. Test passed!
-      done();
-    });
+    }
   });
 
-  it("even if we receive a runtime error, logs for successful transactions need to be processed", function(done) {
-    var tx1, tx2, blockNumber, bytecode;
-
+  it("even if we receive a runtime error, logs for successful transactions need to be processed", async function() {
     // Note: The two transactions queued in this test should exist within the same block.
+    let tx1, tx2;
 
-    stopMining().then(function() {
-      return queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
-    }).then(function(tx) {
-      tx1 = tx;
-      return queueTransaction(accounts[0], null, 1000000, 0, goodBytecode);
-    }).then(function(tx) {
-      tx2 = tx;
-      return startMining();
-    }).then(function() {
-      throw new Error("Execution should never get here as we expected `miner_start` to throw an error")
-    }).catch(function(err) {
+    try {
+      await stopMining()
+
+      tx1 = await queueTransaction(accounts[0], null, 1000000, 0, badBytecode);
+      tx2 = await queueTransaction(accounts[0], null, 1000000, 0, goodBytecode);
+
+      await startMining();
+      assert.fail("Execution should never get here as we expected `miner_start` to throw an error")
+    } catch (err) {
       if (err.message.indexOf("VM Exception while processing transaction") != 0) {
-        return done(new Error("Received error we didn't expect: " + err));
+        assert.fail("Received error we didn't expect: " + err);
       }
+
       // We got the error we wanted. Now check to see if the transaction was processed correctly.
-      getReceipt(tx2).then(function(receipt) {
-        // We should have a receipt for the second transaction - it should have been processed.
-        assert.notEqual(receipt, null);
-        // It also should have logs.
-        assert.notEqual(receipt.logs.length, 0);
+      let receiptTx2 = await web3.eth.getTransactionReceipt(tx2)
 
-        // Now check that there's code at the address, which means it deployed successfully.
-        return getCode(receipt.contractAddress);
-      }).then(function(code) {
-        // Convert hex to a big number and ensure it's not zero.
-        assert(web3.utils.toBN(code).eq(0) == false);
+      // We should have a receipt for the second transaction - it should have been processed.
+      assert.notEqual(receiptTx2, null);
+      assert.notEqual(receiptTx2, {});
 
-        // Hot diggety dog!
-        done();
-      });
-    });
+      // It also should have logs.
+      assert.notEqual(receiptTx2.logs.length, 0);
+
+      // Now check that there's code at the address, which means it deployed successfully.
+      let code = await getCode(receiptTx2.contractAddress);
+
+      // Convert hex to a big number and ensure it's not zero.
+      assert(web3.utils.toBN(code).eq(0) == false);
+
+    }
   });
 
-  it("should return the correct value for eth_mining when miner started and stopped", function() {
-    return stopMining().then(function() {
-      return checkMining();
-    }).then(function(is_mining) {
-      assert(!is_mining);
-      return startMining();
-    }).then(function() {
-      return checkMining();
-    }).then(function(is_mining) {
-      assert(is_mining);
-    });
+  it("should return the correct value for eth_mining when miner started and stopped", async function() {
+    await stopMining()
+    let isMining = await checkMining();
+    assert(!isMining);
+    await startMining();
+    isMining = await checkMining();
+    assert(isMining);
   });
 });

--- a/test/requests.js
+++ b/test/requests.js
@@ -324,6 +324,15 @@ var tests = function(web3) {
     });
   });
 
+  describe("eth_getCode", function() {
+    it("should return 0x for eth_getCode called on a non-contract", function(done) {
+      web3.eth.getCode("0x000000000000000000000000000000000000dEaD", function(err, code) {
+        assert.equal(code, "0x");
+        done();
+      });
+    });
+  });
+
   describe("eth_sign", function() {
     var accounts;
     var signingWeb3;

--- a/test/runtime_errors.js
+++ b/test/runtime_errors.js
@@ -139,7 +139,7 @@ function runTests(web3, provider, extraTests) {
 
         } else {
           assert(response.error === undefined)
-          assert(response.result === "0x0")
+          assert(response.result === "0x")
         }
 
         done();


### PR DESCRIPTION
Fixes #51 

I don't think this issue was completely fixed before.  In particular, the original comment was:

> Not sure if this is an issue or not, but `eth_getCode` returns `0x0` for non-contract accounts. My assumption is that it should return `0x`.

eth_getCode was still returning `0x0`.

I deleted 3 lines from `to.js`, wrote 2 new test cases, and changed some old test cases from expecting `0x0` to expecting `0x`.

Let me know if anything is wrong or missing.