### PR TITLE
Rpc audit inline docs

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -522,9 +522,10 @@ GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callb
 /* 
   RPC AUDIT:  
   TODO ETH: eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_getUncleByBlockHashAndIndex,
-        eth_getUncleByBlockNumberAndIndex, eth_newPendingTransactionFilter,
-        eth_getFilterLogs, eth_getWork, eth_submitWork, eth_submitHashrate
+        eth_getUncleByBlockNumberAndIndex, eth_getWork, eth_submitWork, eth_submitHashrate
+
   TODO DB: db_putString, db_getString, db_putHex, db_getHex
+
   TODO WHISPER: shh_post, shh_newIdentity, shh_hasIdentity, shh_newGroup, shh_addToGroup,
         shh_newFilter, shh_uninstallFilter, shh_getFilterChanges, shh_getMessages
 */

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -519,90 +519,298 @@ GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callb
   this.state.queueTransactionTrace(tx_hash, params, callback);
 };
 
+/* 
+  RPC AUDIT:  
+  TODO ETH: eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_getUncleByBlockHashAndIndex,
+        eth_getUncleByBlockNumberAndIndex, eth_newPendingTransactionFilter,
+        eth_getFilterLogs, eth_getWork, eth_submitWork, eth_submitHashrate
+  TODO DB: db_putString, db_getString, db_putHex, db_getHex
+  TODO WHISPER: shh_post, shh_newIdentity, shh_hasIdentity, shh_newGroup, shh_addToGroup,
+        shh_newFilter, shh_uninstallFilter, shh_getFilterChanges, shh_getMessages
+*/
+
+/**
+ * Returns the number of uncles in a block from a block matching the given block hash.
+ *
+ * @param {DATA, 32 Bytes} hash - hash of a block.
+ * @callback callback 
+ * @param {error} err - Error Object
+ * @param {QUANTITY} result - integer of the number of uncles in this block.
+ */
 GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) {
   callback(null, '0x0');
 };
 
+/**
+ * Returns the number of uncles in a block from a block matching the given block number.
+ *
+ * @param {QUANTITY} blockNumber -  integer of a block number, or the string "latest", "earliest" or "pending". Ex: '0xe8', // 232
+ * @callback callback 
+ * @param {error} err - Error Object
+ * @param {QUANTITY} result - integer of the number of uncles in this block.
+ */
 GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
   callback(null, '0x0');
 };
 
+/**
+ * Returns information about a uncle of a block by hash and uncle index position.
+ *
+ * @param {DATA, 32 Bytes} hash - hash of a block
+ * @param {QUANTITY} index - the uncle's index position.
+ * @callback callback 
+ * @param {error} err - Error Object
+ * @param {Object} result - A block object,
+ */
 GethApiDouble.prototype.eth_getUncleByBlockHashAndIndex = function(hash, index, callback) {
   callback(null, {});
 };
 
+/**
+ * Returns information about a uncle of a block by number and uncle index position.
+ *
+ * @param {QUANTITY} blockNumber - a block number, or the string "earliest", "latest" or "pending", as in the default block parameter.
+ * @param {QUANTITY} uncleIndex - the uncle's index position.
+ * @callback callback 
+ * @param {error} err - Error object
+ * @param {Object} resutl - A block object,
+ */
 GethApiDouble.prototype.eth_getUncleByBlockNumberAndIndex = function(blockNumber, uncleIndex, callback) {
   callback(null, {});
 };
 
+/**
+ * Creates a filter in the node, to notify when new pending transactions arrive. 
+ *
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {QUANTITY} result - A filter id
+ */
 GethApiDouble.prototype.eth_newPendingTransactionFilter = function(callback) {
   callback(null, '0x00');
 };
 
+/**
+ * Returns an array of all logs matching filter with given id.
+ *
+ * @param {QUANTITY} filter_id - A filter id
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {Array of Log Objects} result - More Info: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterlogs
+ */
 GethApiDouble.prototype.eth_getFilterLogs = function(filter_id, callback) {
   callback(null, []);
 };
 
+/**
+ * Returns: An Array with the following elements
+ * 1: DATA, 32 Bytes - current block header pow-hash
+ * 2: DATA, 32 Bytes - the seed hash used for the DAG.
+ * 3: DATA, 32 Bytes - the boundary condition ("target"), 2^256 / difficulty.
+ *
+ * @param {QUANTITY} filter_id - A filter id
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {Array} result - the hash of the current block, the seedHash, and the boundary condition to be met ("target").
+ */
 GethApiDouble.prototype.eth_getWork = function(filter_id, callback) {
   callback(null, []);
 };
 
+/**
+ * Used for submitting a proof-of-work solution
+ *
+ * @param {DATA, 8 Bytes} nonce - The nonce found (64 bits)
+ * @param {DATA, 32 Bytes} powHash - The header's pow-hash (256 bits)
+ * @param {DATA, 32 Bytes} digest - The mix digest (256 bits)
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {Boolean} result - returns true if the provided solution is valid, otherwise false.
+ */
 GethApiDouble.prototype.eth_submitWork = function(nonce, powHash, digest, callback) {
   callback(null, false);
 };
 
+/**
+ * Used for submitting mining hashrate.
+ *
+ * @param {String} hashRate - a hexadecimal string representation (32 bytes) of the hash rate
+ * @param {String} clientID - A random hexadecimal(32 bytes) ID identifying the client
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {Boolean} result - returns true if submitting went through succesfully and false otherwise.
+ */
 GethApiDouble.prototype.eth_submitHashrate = function(hashRate, clientID, callback) {
   callback(null, false);
 };
 
+
+/**
+ * Stores a string in the local database.
+ *
+ * @param {String} dbName - Database name.
+ * @param {String} key - Key name.
+ * @param {String} value - String to store.
+ * @callback callback
+ * @param {error} err - Error object
+ * @param {Boolean} result - returns true if the value was stored, otherwise false.
+ */
 GethApiDouble.prototype.db_putString = function(dbName, key, value, callback) {
   callback(null, false);
 };
 
+/**
+ * Returns string from the local database
+ *
+ * @param {String} dbName - Database name.
+ * @param {String} key - Key name.
+ * @callback callback
+ * @param {error} - Error Object
+ * @param {String} result - The previously stored string.
+ */
 GethApiDouble.prototype.db_getString = function(dbName, key, callback) {
   callback(null, "");
 };
 
+/**
+ * Stores binary data in the local database.
+ *
+ * @param {String} dbName - Database name.
+ * @param {String} key - Key name.
+ * @param {DATA} data - Data to store.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - returns true if the value was stored, otherwise false.
+ */
 GethApiDouble.prototype.db_putHex = function(dbName, key, data, callback) {
   callback(null, false);
 };
 
+/**
+ * Returns binary data from the local database
+ *
+ * @param {String} dbName - Database name.
+ * @param {String} key - Key name.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {DATA} result - The previously stored data.
+ */
 GethApiDouble.prototype.db_getHex = function(dbName, key, callback) {
   callback(null, "0x00");
 };
 
+
+/**
+ * Sends a whisper message.
+ *
+ * @param {DATA, 60 Bytes} from - (optional) The identity of the sender.
+ * @param {DATA, 60 Bytes} to - (optional) The identity of the receiver. When present whisper will encrypt the message so that only the receiver can decrypt it.
+ * @param {Array of DATA} topics - Array of DATA topics, for the receiver to identify messages.
+ * @param {DATA} payload - The payload of the message.
+ * @param {QUANTITY} priority - The integer of the priority in a range from ... (?).
+ * @param {QUANTITY} ttl - integer of the time to live in seconds.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - returns true if the message was sent, otherwise false.
+ */
 GethApiDouble.prototype.shh_post = function(from, to, topics, payload, priority, ttl, callback) {
   callback(null, false);
 };
 
+/**
+ * Creates new whisper identity in the client.
+ *
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {DATA, 60 Bytes} result - the address of the new identiy.
+ */
 GethApiDouble.prototype.shh_newIdentity = function(callback) {
   callback(null, '0x00');
 };
 
+/**
+ * Checks if the client hold the private keys for a given identity.
+ * 
+ * @param {DATA, 60 Bytes} address - The identity address to check.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - returns true if the client holds the privatekey for that identity, otherwise false.
+ */
 GethApiDouble.prototype.shh_hasIdentity = function(address, callback) {
   callback(null, false);
 };
 
+
+/**
+ * Creates a new group.
+ * 
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {DATA, 60 Bytes} result - the address of the new group.
+ */
 GethApiDouble.prototype.shh_newGroup = function(callback) {
   callback(null, '0x00');
 };
 
+/**
+ * Adds a whisper identity to the group
+ * 
+ * @param {DATA, 60 Bytes} - The identity address to add to a group.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - returns true if the identity was successfully added to the group, otherwise false.
+ */
 GethApiDouble.prototype.shh_addToGroup = function(address, callback) {
   callback(null, false);
 };
 
+
+/**
+ * Creates filter to notify, when client receives whisper message matching the filter options.
+ * 
+ * @param {DATA, 60 Bytes} to - (optional) Identity of the receiver. When present it will try to decrypt any incoming message if the client holds the private key to this identity.
+ * @param {Array of DATA} topics - Array of DATA topics which the incoming message's topics should match.
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - returns true if the identity was successfully added to the group, otherwise false.
+ */
 GethApiDouble.prototype.shh_newFilter = function(to, topics, callback) {
   callback(null, false);
 };
 
+/**
+ * Uninstalls a filter with given id. Should always be called when watch is no longer needed. 
+ * Additonally Filters timeout when they aren't requested with shh_getFilterChanges for a period of time.
+ * 
+ * @param {QUANTITY} id - The filter id. Ex: "0x7"
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Boolean} result - true if the filter was successfully uninstalled, otherwise false.
+ */
 GethApiDouble.prototype.shh_uninstallFilter = function(id, callback) {
   callback(null, false);
 };
 
+/**
+ * Polling method for whisper filters. Returns new messages since the last call of this method.
+ * 
+ * @param {QUANTITY} id - The filter id. Ex: "0x7"
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Array} result - More Info: https://github.com/ethereum/wiki/wiki/JSON-RPC#shh_getfilterchanges
+ */
 GethApiDouble.prototype.shh_getFilterChanges = function(id, callback) {
   callback(null, []);
 };
 
+/**
+ * Get all messages matching a filter. Unlike shh_getFilterChanges this returns all messages.
+ * 
+ * @param {QUANTITY} id - The filter id. Ex: "0x7"
+ * @callback callback
+ * @param {error} err - Error Object
+ * @param {Array} result - See: shh_getFilterChanges
+ */
 GethApiDouble.prototype.shh_getMessages = function(id, callback) {
   callback(null, false);
 };

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -519,4 +519,93 @@ GethApiDouble.prototype.debug_traceTransaction = function(tx_hash, params, callb
   this.state.queueTransactionTrace(tx_hash, params, callback);
 };
 
+GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) {
+  callback(null, '0x0');
+};
+
+GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
+  callback(null, '0x0');
+};
+
+GethApiDouble.prototype.eth_getUncleByBlockHashAndIndex = function(hash, index, callback) {
+  callback(null, {});
+};
+
+GethApiDouble.prototype.eth_getUncleByBlockNumberAndIndex = function(blockNumber, uncleIndex, callback) {
+  callback(null, {});
+};
+
+GethApiDouble.prototype.eth_newPendingTransactionFilter = function(callback) {
+  callback(null, '0x00');
+};
+
+GethApiDouble.prototype.eth_getFilterLogs = function(filter_id, callback) {
+  callback(null, []);
+};
+
+GethApiDouble.prototype.eth_getWork = function(filter_id, callback) {
+  callback(null, []);
+};
+
+GethApiDouble.prototype.eth_submitWork = function(nonce, powHash, digest, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.eth_submitHashrate = function(hashRate, clientID, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.db_putString = function(dbName, key, value, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.db_getString = function(dbName, key, callback) {
+  callback(null, "");
+};
+
+GethApiDouble.prototype.db_putHex = function(dbName, key, data, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.db_getHex = function(dbName, key, callback) {
+  callback(null, "0x00");
+};
+
+GethApiDouble.prototype.shh_post = function(from, to, topics, payload, priority, ttl, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.shh_newIdentity = function(callback) {
+  callback(null, '0x00');
+};
+
+GethApiDouble.prototype.shh_hasIdentity = function(address, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.shh_newGroup = function(callback) {
+  callback(null, '0x00');
+};
+
+GethApiDouble.prototype.shh_addToGroup = function(address, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.shh_newFilter = function(to, topics, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.shh_uninstallFilter = function(id, callback) {
+  callback(null, false);
+};
+
+GethApiDouble.prototype.shh_getFilterChanges = function(id, callback) {
+  callback(null, []);
+};
+
+GethApiDouble.prototype.shh_getMessages = function(id, callback) {
+  callback(null, false);
+};
+
+
 module.exports = GethApiDouble;


### PR DESCRIPTION
Add missing RPC methods, Add inline JSDoc

**ETH**: eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber, eth_getUncleByBlockHashAndIndex, eth_getUncleByBlockNumberAndIndex, eth_newPendingTransactionFilter, eth_getFilterLogs, eth_getWork, eth_submitWork, eth_submitHashrate
**DB**: db_putString, db_getString, db_putHex, db_getHex
**WHISPER**: shh_post, shh_newIdentity, shh_hasIdentity, shh_newGroup, shh_addToGroup, shh_newFilter, shh_uninstallFilter, shh_getFilterChanges, shh_getMessages