### PR TITLE
Vrs signature parameters

### DIFF
--- a/lib/utils/receipt.js
+++ b/lib/utils/receipt.js
@@ -34,7 +34,10 @@ Receipt.prototype.toJSON = function() {
     contractAddress: this.contractAddress != null ? to.rpcDataHexString(this.contractAddress) : null,
     logs: this.logs.map(function(log) {return log.toJSON()}),
     status: to.rpcQuantityHexString(this.status),
-    logsBloom: to.rpcDataHexString(this.logsBloom)
+    logsBloom: to.rpcDataHexString(this.logsBloom),
+    v: to.rpcDataHexString(this.tx.v),
+    r: to.rpcDataHexString(this.tx.r),
+    s: to.rpcDataHexString(this.tx.s)
   }
 };
 

--- a/test/requests.js
+++ b/test/requests.js
@@ -953,6 +953,9 @@ var tests = function(web3) {
 
         assert.notEqual(receipt, null, "Transaction receipt shouldn't be null");
         assert.notEqual(contractAddress, null, "Transaction did not create a contract");
+        assert.equal(receipt.hasOwnProperty('v'), true, "Transaction includes v signature parameter");
+        assert.equal(receipt.hasOwnProperty('r'), true, "Transaction includes r signature parameter");
+        assert.equal(receipt.hasOwnProperty('s'), true, "Transaction includes s signature parameter");
         done();
       });
     });
@@ -963,7 +966,9 @@ var tests = function(web3) {
 
         assert.notEqual(result, null, "Transaction result shouldn't be null");
         assert.equal(result.hash, initialTransaction, "Resultant hash isn't what we expected")
-
+        assert.equal(result.hasOwnProperty('v'), true, "Transaction includes v signature parameter");
+        assert.equal(result.hasOwnProperty('r'), true, "Transaction includes r signature parameter");
+        assert.equal(result.hasOwnProperty('s'), true, "Transaction includes s signature parameter");
         done();
       });
     });


### PR DESCRIPTION
This adds v,r and s signature parameters to the eth_getTransaction and eth_getTransactionReceipt methods.  It is not part of the official web3 [API](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransaction), however both Parity and Geth provide these parameters allowing the user to verify transactions and blocks.