### PR TITLE
Set 'to' to null when deploy contract

### DIFF
--- a/lib/utils/txhelper.js
+++ b/lib/utils/txhelper.js
@@ -26,6 +26,11 @@ module.exports = {
       input: to.rpcDataHexString(tx.data),
     };
 
+    // Check tx is contract creation
+    if (resultJSON.to === '0x0' || resultJSON.to === '0x') {
+      resultJSON.to = null;
+    }
+
     if (tx.v && tx.v.length > 0 &&
         tx.r && tx.r.length > 0 &&
         tx.s && tx.s.length > 0) {


### PR DESCRIPTION
`to` should be null when it is a transaction for contraction creation.

Resolves [trufflesuite/ganache-cli/issues/579](https://github.com/trufflesuite/ganache-cli/issues/579)
