### PR TITLE
Update geth_api_double removed implemented methods

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -595,29 +595,6 @@ GethApiDouble.prototype.eth_getUncleByBlockNumberAndIndex = function(blockNumber
 };
 
 /**
- * Creates a filter in the node, to notify when new pending transactions arrive.
- *
- * @callback callback
- * @param {error} err - Error object
- * @param {QUANTITY} result - A filter id
- */
-GethApiDouble.prototype.eth_newPendingTransactionFilter = function(callback) {
-  callback(null, "0x00");
-};
-
-/**
- * Returns an array of all logs matching filter with given id.
- *
- * @param {QUANTITY} filterId - A filter id
- * @callback callback
- * @param {error} err - Error object
- * @param {Array of Log Objects} result - More Info: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getfilterlogs
- */
-GethApiDouble.prototype.eth_getFilterLogs = function(filterId, callback) {
-  callback(null, []);
-};
-
-/**
  * Returns: An Array with the following elements
  * 1: DATA, 32 Bytes - current block header pow-hash
  * 2: DATA, 32 Bytes - the seed hash used for the DAG.


### PR DESCRIPTION
All the block filter methods are already implemented in: https://github.com/MetaMask/provider-engine/blob/master/subproviders/filters.js#L144-L175

This is just cleaning up some methods that slipped past the RPC audit.