### PR TITLE
Issue 173: Adding uncle count support

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -553,7 +553,7 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
   this.state.getBlock(hash, function(err, block) {
     if (err) {
       if (err.message && err.message.indexOf("Key not found in database") >= 0) {
-        const error = new Error("Unknown block number");
+        const error = new Error("Unknown block hash");
         callback(error, null);
       }
       callback(err, "0x0");
@@ -575,12 +575,17 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
   this.state.getBlock(blockNumber, function(err, block) {
-    if (!err) {
+    if (err) {
+      if (err.message && err.message.indexOf("index out of range") >= 0) {
+        const error = new Error("Unknown block number");
+        callback(error, null);
+      }
+      callback(err, "0x0");
+    } else {
       const { uncleHeaders } = block;
       const uncleCount = uncleHeaders.length;
       callback(null, uncleCount);
     }
-    callback(null, "0x0");
   });
 };
 

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -555,9 +555,10 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
     if (err) {
       if (err.message && err.message.indexOf("Key not found in database") >= 0) {
         const error = new Error("Unknown block hash");
-        callback(error, null);
+        callback(error);
+      } else {
+        callback(err);
       }
-      callback(err, "0x0");
     } else {
       const { uncleHeaders } = block;
       const uncleCount = uncleHeaders.length;
@@ -580,9 +581,10 @@ GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, c
     if (err) {
       if (err.message && err.message.indexOf("index out of range") >= 0) {
         const error = new Error("Unknown block number");
-        callback(error, null);
+        callback(error);
+      } else {
+        callback(err);
       }
-      callback(err, "0x0");
     } else {
       const { uncleHeaders } = block;
       const uncleCount = uncleHeaders.length;

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -547,7 +547,8 @@ GethApiDouble.prototype.debug_traceTransaction = function(txHash, params, callba
  *
  * @param {string} hash - Hash of a block (32 bytes).
  * @callback callback
- * @param {number} result - Integer count of uncles in this block.
+ * @throws Block hash not found
+ * @returns {number} result - Integer count of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) {
   this.state.getBlock(hash, function(err, block) {
@@ -568,10 +569,11 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
 /**
  * Returns the number of uncles in a block matching the given block number.
  *
- * @param {number| string} blockNumber - Integer block number
- *  ^integer of a block number, or the string "latest", "earliest" or "pending". Ex: '0xe8', // 232
+ * @param {number|string} blockNumber - Integer block number, "latest", "earliest" or "pending"
  * @callback callback
- * @param {number} result - Integer count of uncles in this block.
+ * @throws - {OutOfRange} Block number is either negative or higher than block height
+ * @throws - Invalid tag detected
+ * @returns {number} result - Integer count of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
   this.state.getBlock(blockNumber, function(err, block) {

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -551,7 +551,14 @@ GethApiDouble.prototype.debug_traceTransaction = function(txHash, params, callba
  * @param {QUANTITY} result - integer of the number of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) {
-  callback(null, "0x0");
+  this.state.getBlock(hash, function(err, block) {
+    if (!err) {
+      const { uncleHeaders } = block;
+      const uncleCount = uncleHeaders.length;
+      callback(null, uncleCount);
+    }
+    callback(null, "0x0");
+  });
 };
 
 /**
@@ -564,7 +571,14 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
  * @param {QUANTITY} result - integer of the number of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
-  callback(null, "0x0");
+  this.state.getBlock(blockNumber, function(err, block) {
+    if (!err) {
+      const { uncleHeaders } = block;
+      const uncleCount = uncleHeaders.length;
+      callback(null, uncleCount);
+    }
+    callback(null, "0x0");
+  });
 };
 
 /**

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -571,7 +571,7 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
  *
  * @param {number|string} blockNumber - Integer block number, "latest", "earliest" or "pending"
  * @callback callback
- * @throws - {OutOfRange} Block number is either negative or higher than block height
+ * @throws {OutOfRange} - Block number is either negative or higher than block height
  * @throws - Invalid tag detected
  * @returns {number} result - Integer count of uncles in this block.
  */

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -568,7 +568,7 @@ GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) 
 /**
  * Returns the number of uncles in a block matching the given block number.
  *
- * @param {number} blockNumber - Integer block number
+ * @param {number| string} blockNumber - Integer block number
  *  ^integer of a block number, or the string "latest", "earliest" or "pending". Ex: '0xe8', // 232
  * @callback callback
  * @param {number} result - Integer count of uncles in this block.

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -543,32 +543,35 @@ GethApiDouble.prototype.debug_traceTransaction = function(txHash, params, callba
 */
 
 /**
- * Returns the number of uncles in a block from a block matching the given block hash.
+ * Returns the number of uncles in a block matching the given block hash.
  *
- * @param {DATA, 32 Bytes} hash - hash of a block.
+ * @param {string} hash - Hash of a block (32 bytes).
  * @callback callback
- * @param {error} err - Error Object
- * @param {QUANTITY} result - integer of the number of uncles in this block.
+ * @param {number} result - Integer count of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockHash = function(hash, callback) {
   this.state.getBlock(hash, function(err, block) {
-    if (!err) {
+    if (err) {
+      if (err.message && err.message.indexOf("Key not found in database") >= 0) {
+        const error = new Error("Unknown block number");
+        callback(error, null);
+      }
+      callback(err, "0x0");
+    } else {
       const { uncleHeaders } = block;
       const uncleCount = uncleHeaders.length;
       callback(null, uncleCount);
     }
-    callback(null, "0x0");
   });
 };
 
 /**
- * Returns the number of uncles in a block from a block matching the given block number.
+ * Returns the number of uncles in a block matching the given block number.
  *
- * @param {QUANTITY} blockNumber -
+ * @param {number} blockNumber - Integer block number
  *  ^integer of a block number, or the string "latest", "earliest" or "pending". Ex: '0xe8', // 232
  * @callback callback
- * @param {error} err - Error Object
- * @param {QUANTITY} result - integer of the number of uncles in this block.
+ * @param {number} result - Integer count of uncles in this block.
  */
 GethApiDouble.prototype.eth_getUncleCountByBlockNumber = function(blockNumber, callback) {
   this.state.getBlock(blockNumber, function(err, block) {

--- a/lib/utils/block_helper.js
+++ b/lib/utils/block_helper.js
@@ -29,7 +29,7 @@ module.exports = {
           return to.txHash(tx);
         }
       }),
-      uncles: [] // block.uncleHeaders.map(function(uncleHash) {return to.hex(uncleHash)})
+      uncles: block.uncleHeaders
     };
   }
 };

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -158,8 +158,10 @@ ForkedBlockchain.prototype.isFallbackBlock = function(value, callback) {
 };
 
 ForkedBlockchain.prototype.isBlockHash = function(value) {
-  return (typeof value === "string" && value.indexOf("0x") === 0 && value.length > 42) ||
-    (Buffer.isBuffer(value) && value.length >= 32);
+  return (
+    (typeof value === "string" && value.indexOf("0x") === 0 && value.length > 42) ||
+    (Buffer.isBuffer(value) && value.length >= 32)
+  );
 };
 
 ForkedBlockchain.prototype.isFallbackBlockHash = function(value, callback) {
@@ -216,6 +218,7 @@ ForkedBlockchain.prototype.getFallbackBlock = function(numberOrHash, cb) {
     block.header.gasUsed = utils.toBuffer(json.gasUsed);
     block.header.timestamp = utils.toBuffer(json.timestamp);
     block.header.extraData = utils.toBuffer(json.extraData);
+    block.uncleHeaders = json.uncles;
 
     (json.transactions || []).forEach(function(txJson, index) {
       block.transactions.push(txhelper.fromJSON(txJson));

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -24,7 +24,7 @@ describe("Uncle support", function() {
         const params = [invalidHash];
         await rpcSend(method, params, web3);
       } catch (error) {
-        const expectedErrorMessage = "Unknown block number";
+        const expectedErrorMessage = "Unknown block hash";
         assert.strictEqual(error.message, expectedErrorMessage);
       }
     });
@@ -37,6 +37,18 @@ describe("Uncle support", function() {
       const { result } = await rpcSend(method, params, web3);
       assert.notStrictEqual(result, "0x0");
       assert.strictEqual(result, uncles.length);
+
+      // Validate a bad block number lookup
+      try {
+        const method = "eth_getUncleCountByBlockNumber";
+        const { number } = await web3.eth.getBlock("latest");
+        const invalidBlockNumber = number + 1000;
+        const params = [invalidBlockNumber];
+        await rpcSend(method, params, web3);
+      } catch (error) {
+        const expectedErrorMessage = "Unknown block number";
+        assert.strictEqual(error.message, expectedErrorMessage);
+      }
     });
   });
 });

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -99,7 +99,7 @@ describe("Uncle support", function() {
     });
 
     it("by forking mainnet", async function() {
-      this.timeout(8000);
+      this.timeout(10000);
       // Set up forking from mainnet
       const forkedWeb3 = new Web3(
         Ganache.provider({
@@ -118,8 +118,8 @@ describe("Uncle support", function() {
       // Validate single uncle count using Ganache rpc method
       const method = "eth_getUncleCountByBlockNumber";
       let params = [oneUncleBlock];
-      let count = await rpcSend(method, params, forkedWeb3);
-      assert.strictEqual(testBlock.uncles.length, count.result);
+      let { result } = await rpcSend(method, params, forkedWeb3);
+      assert.strictEqual(testBlock.uncles.length, result);
 
       // Directly validate a double uncle count
       testBlock = await forkedWeb3.eth.getBlock(twoUncleBlock);
@@ -127,8 +127,8 @@ describe("Uncle support", function() {
 
       // Validate double uncle count using Ganache rpc method
       params = [twoUncleBlock];
-      count = await rpcSend(method, params, forkedWeb3);
-      assert.strictEqual(testBlock.uncles.length, count.result);
+      ({ result } = await rpcSend(method, params, forkedWeb3));
+      assert.strictEqual(testBlock.uncles.length, result);
     });
   });
 });

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -39,10 +39,22 @@ describe("Uncle support", function() {
       const { result } = await rpcSend(method, params, web3);
       assert.strictEqual(result, uncles.length);
 
-      // Validate a BAD block number lookup
+      // Validate a VERY HIGH block number lookup
       try {
         const { number } = await web3.eth.getBlock("latest");
         const invalidBlockNumber = number + 1000;
+        const method = "eth_getUncleCountByBlockNumber";
+        const params = [invalidBlockNumber];
+        await rpcSend(method, params, web3);
+        assert.fail("Invalid block number was processed!");
+      } catch (error) {
+        const expectedErrorMessage = "Unknown block number";
+        assert.strictEqual(error.message, expectedErrorMessage);
+      }
+
+      // Validate a NEGATIVE block number lookup
+      try {
+        const invalidBlockNumber = -1;
         const method = "eth_getUncleCountByBlockNumber";
         const params = [invalidBlockNumber];
         await rpcSend(method, params, web3);

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -1,0 +1,27 @@
+const assert = require("assert");
+const { rpcSend } = require("./helpers/rpc");
+const { preloadWeb3 } = require("./helpers/pretest_setup");
+
+describe("Uncle support", function() {
+  describe("retrieving uncles", function() {
+    const services = preloadWeb3();
+
+    it("by hash", async function() {
+      const { web3 } = services;
+      const { hash } = await web3.eth.getBlock("latest");
+      const method = "eth_getUncleCountByBlockHash";
+      const params = [hash];
+      const { result } = await rpcSend(method, params, web3);
+      assert.notStrictEqual(result, "0x0");
+    });
+
+    it("by block number", async function() {
+      const { web3 } = services;
+      const { number } = await web3.eth.getBlock("latest");
+      const method = "eth_getUncleCountByBlockNumber";
+      const params = [number];
+      const { result } = await rpcSend(method, params, web3);
+      assert.notStrictEqual(result, "0x0");
+    });
+  });
+});

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -14,7 +14,6 @@ describe("Uncle support", function() {
       const method = "eth_getUncleCountByBlockHash";
       const params = [hash];
       const { result } = await rpcSend(method, params, web3);
-      assert.notStrictEqual(result, "0x0");
       assert.strictEqual(result, uncles.length);
 
       // Validate a bad hash lookup
@@ -31,18 +30,28 @@ describe("Uncle support", function() {
 
     it("by block number", async function() {
       const { web3 } = services;
+
+      // Validate a good block number lookup
       const { number, uncles } = await web3.eth.getBlock("latest");
       const method = "eth_getUncleCountByBlockNumber";
       const params = [number];
       const { result } = await rpcSend(method, params, web3);
-      assert.notStrictEqual(result, "0x0");
       assert.strictEqual(result, uncles.length);
+
+      // Validate a good block tag lookup
+      const tags = ["latest", "earliest", "pending"];
+      tags.forEach(async(tag) => {
+        const method = "eth_getUncleCountByBlockNumber";
+        const params = [tag];
+        const { result } = await rpcSend(method, params, web3);
+        assert.strictEqual(result, uncles.length);
+      });
 
       // Validate a bad block number lookup
       try {
-        const method = "eth_getUncleCountByBlockNumber";
         const { number } = await web3.eth.getBlock("latest");
         const invalidBlockNumber = number + 1000;
+        const method = "eth_getUncleCountByBlockNumber";
         const params = [invalidBlockNumber];
         await rpcSend(method, params, web3);
       } catch (error) {

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -8,20 +8,35 @@ describe("Uncle support", function() {
 
     it("by hash", async function() {
       const { web3 } = services;
-      const { hash } = await web3.eth.getBlock("latest");
+
+      // Validate a good hash lookup
+      const { hash, uncles } = await web3.eth.getBlock("latest");
       const method = "eth_getUncleCountByBlockHash";
       const params = [hash];
       const { result } = await rpcSend(method, params, web3);
       assert.notStrictEqual(result, "0x0");
+      assert.strictEqual(result, uncles.length);
+
+      // Validate a bad hash lookup
+      try {
+        const method = "eth_getUncleCountByBlockHash";
+        const invalidHash = `0x${"f".repeat(64)}`;
+        const params = [invalidHash];
+        await rpcSend(method, params, web3);
+      } catch (error) {
+        const expectedErrorMessage = "Unknown block number";
+        assert.strictEqual(error.message, expectedErrorMessage);
+      }
     });
 
     it("by block number", async function() {
       const { web3 } = services;
-      const { number } = await web3.eth.getBlock("latest");
+      const { number, uncles } = await web3.eth.getBlock("latest");
       const method = "eth_getUncleCountByBlockNumber";
       const params = [number];
       const { result } = await rpcSend(method, params, web3);
       assert.notStrictEqual(result, "0x0");
+      assert.strictEqual(result, uncles.length);
     });
   });
 });

--- a/test/eth_getUncles.js
+++ b/test/eth_getUncles.js
@@ -98,10 +98,10 @@ describe("Uncle support", function() {
       });
     });
 
-    it("forking mainnet", async function() {
-      this.timeout(5000);
+    it("by forking mainnet", async function() {
+      this.timeout(8000);
       // Set up forking from mainnet
-      const fWeb3 = new Web3(
+      const forkedWeb3 = new Web3(
         Ganache.provider({
           fork: "https://mainnet.infura.io"
         })
@@ -111,13 +111,24 @@ describe("Uncle support", function() {
       const oneUncleBlock = 6790228;
       const twoUncleBlock = 6795996;
 
-      // Validate a single uncle count
-      let testBlock = await fWeb3.eth.getBlock(oneUncleBlock);
+      // Directly validate a single uncle count
+      let testBlock = await forkedWeb3.eth.getBlock(oneUncleBlock);
       assert.strictEqual(testBlock.uncles.length, 1);
 
-      // Validate a single uncle count
-      testBlock = await fWeb3.eth.getBlock(twoUncleBlock);
+      // Validate single uncle count using Ganache rpc method
+      const method = "eth_getUncleCountByBlockNumber";
+      let params = [oneUncleBlock];
+      let count = await rpcSend(method, params, forkedWeb3);
+      assert.strictEqual(testBlock.uncles.length, count.result);
+
+      // Directly validate a double uncle count
+      testBlock = await forkedWeb3.eth.getBlock(twoUncleBlock);
       assert.strictEqual(testBlock.uncles.length, 2);
+
+      // Validate double uncle count using Ganache rpc method
+      params = [twoUncleBlock];
+      count = await rpcSend(method, params, forkedWeb3);
+      assert.strictEqual(testBlock.uncles.length, count.result);
     });
   });
 });

--- a/test/helpers/compile_deploy.js
+++ b/test/helpers/compile_deploy.js
@@ -1,0 +1,50 @@
+const { readFileSync } = require("fs");
+const { compile } = require("solc");
+
+/**
+ * Compile and deploy the selected contract(s)
+ * @param {String} contractPath  Path to contracts directory
+ * @param {String} mainContractName  Name of the main contract (without .sol extension)
+ * @param {Array|String} contractFileNames List of imported contracts
+ * @param {Object} web3 Web3 interface
+ * @returns {Object} context
+ */
+async function compileAndDeploy(contractPath, mainContractName, contractFileNames = [], web3) {
+  // Organize contract(s) for compilation
+  const selectedContracts = contractFileNames.length === 0 ? [mainContractName] : contractFileNames;
+  const contractSources = selectedContracts.map((contractName) => {
+    return { [`${contractName}.sol`]: readFileSync(`${contractPath}${contractName}.sol`, "utf8") };
+  });
+
+  const sources = Object.assign({}, ...contractSources);
+
+  const { contracts } = compile({ sources }, 1);
+  const compiledMainContract = contracts[`${mainContractName}.sol:${mainContractName}`];
+  const bytecode = `0x${compiledMainContract.bytecode}`;
+  const abi = JSON.parse(compiledMainContract.interface);
+  const contract = new web3.eth.Contract(abi);
+
+  const accounts = await web3.eth.getAccounts();
+
+  // Retrieve block gas limit
+  const { gasLimit } = await web3.eth.getBlock("latest");
+  const instance = await contract.deploy({ data: bytecode }).send({ from: accounts[0], gas: gasLimit });
+
+  // TODO: ugly workaround - not sure why this is necessary.
+  if (!instance._requestManager.provider) {
+    instance._requestManager.setProvider(web3.eth._provider);
+  }
+
+  return {
+    abi,
+    accounts,
+    bytecode,
+    contract,
+    instance,
+    sources
+  };
+}
+
+exports = module.exports = {
+  compileAndDeploy
+};

--- a/test/helpers/compile_deploy.js
+++ b/test/helpers/compile_deploy.js
@@ -30,11 +30,6 @@ async function compileAndDeploy(contractPath, mainContractName, contractFileName
   const { gasLimit } = await web3.eth.getBlock("latest");
   const instance = await contract.deploy({ data: bytecode }).send({ from: accounts[0], gas: gasLimit });
 
-  // TODO: ugly workaround - not sure why this is necessary.
-  if (!instance._requestManager.provider) {
-    instance._requestManager.setProvider(web3.eth._provider);
-  }
-
   return {
     abi,
     accounts,

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -2,6 +2,12 @@ const fs = require("fs");
 const solc = require("solc");
 const path = require("path");
 
+/**
+ * compileAndDeploy
+ * @param {string} contractPath path to the directory containing contract
+ * @param {string} contractName name of the top most contract
+ * @param {object} web3 Web3 interface
+ */
 async function compileAndDeploy(contractPath, contractName, web3) {
   let contractFilename = path.basename(contractPath);
 

--- a/test/helpers/pretest_setup.js
+++ b/test/helpers/pretest_setup.js
@@ -43,9 +43,6 @@ const preloadWeb3 = (mnemonics) => {
     const options = typeof mnemonics === "string" ? {} : { mnemonics };
     const provider = Ganache.provider(options);
     const web3 = new Web3(provider);
-    // console.log(provider);
-    // console.log(web3);
-    // process.exit(1);
 
     context.provider = provider;
     context.options = options;

--- a/test/helpers/pretest_setup.js
+++ b/test/helpers/pretest_setup.js
@@ -1,0 +1,61 @@
+const Web3 = require("web3");
+const Ganache = require("../../index");
+const { join } = require("path");
+const { compileAndDeploy } = require("./compile_deploy");
+
+const preloadContracts = (mainContractName = "", subContractNames = [], contractPath = "../contracts/", mnemonics) => {
+  const context = {};
+
+  before("Setting up web3 and contract", async function() {
+    this.timeout(10000);
+
+    const options = typeof mnemonics === "string" ? {} : { mnemonics };
+    const provider = Ganache.provider(options);
+    const web3 = new Web3(provider);
+
+    const { abi, accounts, bytecode, contract, instance, sources } = await compileAndDeploy(
+      join(__dirname, contractPath),
+      mainContractName,
+      subContractNames,
+      web3
+    );
+
+    context.abi = abi;
+    context.accounts = accounts;
+    context.bytecode = bytecode;
+    context.contract = contract;
+    context.instance = instance;
+    context.provider = provider;
+    context.options = options;
+    context.sources = sources;
+    context.web3 = web3;
+  });
+
+  return context;
+};
+
+const preloadWeb3 = (mnemonics) => {
+  const context = {};
+
+  before("Setting up web3", async function() {
+    this.timeout(10000);
+
+    const options = typeof mnemonics === "string" ? {} : { mnemonics };
+    const provider = Ganache.provider(options);
+    const web3 = new Web3(provider);
+    // console.log(provider);
+    // console.log(web3);
+    // process.exit(1);
+
+    context.provider = provider;
+    context.options = options;
+    context.web3 = web3;
+  });
+
+  return context;
+};
+
+module.exports = {
+  preloadContracts,
+  preloadWeb3
+};

--- a/test/helpers/rpc.js
+++ b/test/helpers/rpc.js
@@ -1,0 +1,25 @@
+const pify = require("pify");
+
+/**
+ * Generic RPC interface
+ *
+ * @param {string} method Name of provider method call
+ * @param {Array} params Argument for method call
+ * @param {Object} web3 Web3 interface
+ */
+
+const rpcSend = (method = "", params = [], web3) => {
+  const send = pify(web3._provider.send.bind(web3._provider));
+  // an "id" is required here because the web3 websocket provider (v1.0.0-beta.35) throws if it is
+  // missing (it's probably just a bug on their end)
+  return send({
+    id: "1",
+    jsonrpc: "2.0",
+    method,
+    params
+  });
+};
+
+module.exports = {
+  rpcSend
+};


### PR DESCRIPTION
### PR Summary
**geth_api_double.js**
- Added RPC methods for get eth_getUncleCountBy*

**block_helper.js**
- Set uncle array

**forkedblockchain.js**
- Added uncle stats to a new forked block

**compileAndDeploy.js, pretest_setup.js**
- Adding these files to each test as a refactoring effort until merged into `develop`

**rpc.js**
- Starting to modularizing the rpc methods as part of the refactoring effort.