### PR TITLE
Issue 237: Compute correct block hash

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3320,8 +3320,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereum-common": {
@@ -3430,9 +3439,9 @@
       }
     },
     "ethereum-common": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.16.tgz",
-      "integrity": "sha1-mh4Wnq00q3XgifUMpRK/0PvRJlU="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereumjs-abi": {
       "version": "0.6.5",
@@ -3468,33 +3477,21 @@
       }
     },
     "ethereumjs-block": {
-      "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
-      "integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
+      "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
       "requires": {
-        "async": "^1.5.2",
-        "ethereum-common": "0.0.16",
-        "ethereumjs-tx": "^1.0.0",
-        "ethereumjs-util": "^4.0.1",
+        "async": "^2.0.1",
+        "ethereumjs-common": "^0.6.0",
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
         "merkle-patricia-tree": "^2.1.2"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "ethereumjs-util": {
-          "version": "4.5.0",
-          "resolved": "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
-          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
-          "requires": {
-            "bn.js": "^4.8.0",
-            "create-hash": "^1.1.2",
-            "keccakjs": "^0.2.0",
-            "rlp": "^2.0.0",
-            "secp256k1": "^3.0.1"
-          }
+        "ethereumjs-common": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.1.tgz",
+          "integrity": "sha512-4jOrfDu9qOBTTGGb3zrfT1tE1Hyc6a8LJpEk0Vk9AYlLkBY7crjVICyJpRvjNI+KLDMpMITMw3eWVZOLMtZdhw=="
         }
       }
     },
@@ -10070,8 +10067,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereumjs-abi": {
@@ -10080,6 +10086,18 @@
           "requires": {
             "bn.js": "^4.10.0",
             "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+          "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+          "requires": {
+            "async": "^2.0.1",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "^1.2.2",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
           }
         },
         "ws": {
@@ -10120,23 +10138,20 @@
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "websocket": {
           "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-          "dev": true,
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
           "requires": {
             "debug": "^2.2.0",
             "nan": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eth-sig-util": "2.0.2",
     "ethereumjs-abi": "0.6.5",
     "ethereumjs-account": "2.0.5",
-    "ethereumjs-block": "1.2.2",
+    "ethereumjs-block": "2.1.0",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "5.2.0",
     "ethereumjs-vm": "2.4.0",

--- a/test/requests.js
+++ b/test/requests.js
@@ -1,6 +1,7 @@
 const Web3 = require("web3");
 const Web3WsProvider = require("web3-providers-ws");
 const Transaction = require("ethereumjs-tx");
+const BlockHeader = require("ethereumjs-block/header");
 const utils = require("ethereumjs-util");
 const assert = require("assert");
 const Ganache = require(process.env.TEST_BUILD
@@ -198,6 +199,28 @@ const tests = function(web3) {
 
       assert.strictEqual(block.transactions.length, 1, "Latest block should have one transaction");
       assert.strictEqual(block.transactions[0], txHash, "Transaction hashes don't match");
+    });
+
+    it("should return correct block hash", async function() {
+      const block = await web3.eth.getBlock("latest", true);
+      const header = new BlockHeader({
+        parentHash: block.parentHash,
+        uncleHash: block.sha3Uncles,
+        coinbase: block.miner,
+        stateRoot: block.stateRoot,
+        transactionsTrie: block.transactionsRoot,
+        receiptTrie: block.receiptsRoot,
+        bloom: block.logsBloom,
+        difficulty: parseInt(block.difficulty, 10),
+        number: block.number,
+        gasLimit: block.gasLimit,
+        gasUsed: block.gasUsed,
+        timestamp: block.timestamp,
+        extraData: block.extraData,
+        mixHash: block.mixHash,
+        nonce: block.nonce
+      });
+      assert.strictEqual(block.hash, "0x" + header.hash().toString("hex"), "Block hash matches computed hash");
     });
   });
 


### PR DESCRIPTION
Closes #237 

The fix is to upgrade `ethereumjs-block` to a newer version (`2.1.0`) which uses the correct default value for the nonce field.