### PR TITLE
Fix LevelDB creation from previous snapshot

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -30,11 +30,11 @@ Database.prototype.initialize = function(callback) {
     if (err) {
       return callback(err);
     }
-    levelup(
-      self.options.db || encode(cachedown(directory, filedown).maxSize(100)),
-      { valueEncoding: "json" },
-      finishInitializing
-    );
+    if (self.options.db) {
+      levelup(self.options.db, { valueEncoding: "json" }, finishInitializing);
+    } else {
+      levelup(encode(cachedown(directory, filedown).maxSize(100), { valueEncoding: "json" }), {}, finishInitializing);
+    }
   });
 
   function finishInitializing(err, db) {


### PR DESCRIPTION
Wrong option for `encoding-down`.
Fixes https://github.com/trufflesuite/ganache-cli/issues/597