### PR TITLE
Overload eventemitter on method to handle data listeners

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -62,6 +62,7 @@ const defaultOptions = {
 };
 
 Provider.prototype = Object.create(EventEmitter.prototype);
+Provider.prototype.oldOn = Provider.prototype.on;
 Provider.prototype.constructor = Provider;
 
 Provider.prototype._applyDefaultOptions = function(options) {
@@ -128,6 +129,16 @@ Provider.prototype.send = function(payload, callback) {
   } else {
     self._queueRequest(payload, intermediary);
   }
+};
+
+Provider.prototype.on = function(eventName, listener) {
+  if (eventName === "data") {
+    const maxListeners = this.getMaxListeners();
+    if (this.listenerCount(eventName) + 1 > maxListeners) {
+      this.setMaxListeners(maxListeners + 1);
+    }
+  }
+  this.oldOn(eventName, listener);
 };
 
 Provider.prototype.close = function(callback) {


### PR DESCRIPTION
This essentially bypasses the memoryleak warning for data event listeners by increasing the max listeners as needed.

This fixes #267, but I'm not sure if this approach is even a sane one. A better implementation is fixing the issue at the core in web3.js (see #267 for more details).