### PR TITLE
Fix trace transaction

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -80,54 +80,7 @@ BlockchainDouble.prototype.initialize = function(accounts, callback) {
       // forked blockchain without going through the other setup is a little gross.
       self.stateTrie = self.createStateTrie(self.data.trie_db, root);
 
-      self.vm =
-        options.vm ||
-        new VM({
-          state: self.stateTrie,
-          blockchain: {
-            // EthereumJS VM needs a blockchain object in order to get block information.
-            // When calling getBlock() it will pass a number that's of a Buffer type.
-            // Unfortunately, it uses a 64-character buffer (when converted to hex) to
-            // represent block numbers as well as block hashes. Since it's very unlikely
-            // any block number will get higher than the maximum safe Javascript integer,
-            // we can convert this buffer to a number ahead of time before calling our
-            // own getBlock(). If the conversion succeeds, we have a block number.
-            // If it doesn't, we have a block hash. (Note: Our implementation accepts both.)
-            getBlock: function(number, done) {
-              try {
-                number = to.number(number);
-              } catch (e) {
-                // Do nothing; must be a block hash.
-              }
-
-              self.getBlock(number, done);
-            }
-          },
-          // Ethereum-VM 2.5.0 no longer allows using state and activatePrecompiles
-          // options at the same time (we mimic `activatePrecompiles` ourselves
-          // in createStateTrie now).
-          activatePrecompiles: false,
-          hardfork: options.hardfork,
-          allowUnlimitedContractSize: options.allowUnlimitedContractSize
-        });
-
-      if (options.debug === true) {
-        // log executed opcodes, including args as hex
-        self.vm.on("step", function(info) {
-          var name = info.opcode.name;
-          var argsNum = info.opcode.in;
-          if (argsNum) {
-            var args = info.stack
-              .slice(-argsNum)
-              .map((arg) => to.hex(arg))
-              .join(" ");
-
-            self.logger.log(`${name} ${args}`);
-          } else {
-            self.logger.log(name);
-          }
-        });
-      }
+      self.vm = options.vm || self.createVMFromStateTrie(self.stateTrie);
 
       if (options.time) {
         self.setTime(options.time);
@@ -164,6 +117,58 @@ BlockchainDouble.prototype.initialize = function(accounts, callback) {
       });
     });
   });
+};
+
+BlockchainDouble.prototype.createVMFromStateTrie = function(state) {
+  const self = this;
+  const vm = new VM({
+    state: state,
+    blockchain: {
+      // EthereumJS VM needs a blockchain object in order to get block information.
+      // When calling getBlock() it will pass a number that's of a Buffer type.
+      // Unfortunately, it uses a 64-character buffer (when converted to hex) to
+      // represent block numbers as well as block hashes. Since it's very unlikely
+      // any block number will get higher than the maximum safe Javascript integer,
+      // we can convert this buffer to a number ahead of time before calling our
+      // own getBlock(). If the conversion succeeds, we have a block number.
+      // If it doesn't, we have a block hash. (Note: Our implementation accepts both.)
+      getBlock: function(number, done) {
+        try {
+          number = to.number(number);
+        } catch (e) {
+          // Do nothing; must be a block hash.
+        }
+
+        self.getBlock(number, done);
+      }
+    },
+    // Ethereum-VM 2.5.0 no longer allows using state and activatePrecompiles
+    // options at the same time (we mimic `activatePrecompiles` ourselves
+    // in createStateTrie now).
+    activatePrecompiles: false,
+    hardfork: self.options.hardfork,
+    allowUnlimitedContractSize: self.options.allowUnlimitedContractSize
+  });
+
+  if (self.options.debug === true) {
+    // log executed opcodes, including args as hex
+    vm.on("step", function(info) {
+      var name = info.opcode.name;
+      var argsNum = info.opcode.in;
+      if (argsNum) {
+        var args = info.stack
+          .slice(-argsNum)
+          .map((arg) => to.hex(arg))
+          .join(" ");
+
+        self.logger.log(`${name} ${args}`);
+      } else {
+        self.logger.log(name);
+      }
+    });
+  }
+
+  return vm;
 };
 
 BlockchainDouble.prototype.createStateTrie = function(db, root) {
@@ -337,9 +342,9 @@ BlockchainDouble.prototype.putAccount = function(account, address, callback) {
       return callback(err);
     }
 
-    // stateManager.cache.flush is no longer public, but `getStateRoot`
-    // does the same thing now.
-    self.vm.stateManager.getStateRoot(callback);
+    // this.vm.stateManager.putAccount only stores the accounts in cache, not in the trie.
+    // we need to flush the cache to the trie in order for it to be available in the db.
+    self.vm.stateManager._cache.flush(callback);
   });
 };
 
@@ -554,13 +559,14 @@ BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
  *
  * Process the passed in block and included transactions
  *
+ * @param  {VM} vm             the vm to use when running the block
  * @param  {Block} block       block to process
  * @param  {Boolean} commit    Whether or not changes should be committed to the state
  * trie and the block appended to the end of the chain.
  * @param  {Function} callback Callback function when transaction processing is completed.
  * @return [type]              [description]
  */
-BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
+BlockchainDouble.prototype.processBlock = function(vm, block, commit, callback) {
   var self = this;
 
   if (typeof commit === "function") {
@@ -568,7 +574,7 @@ BlockchainDouble.prototype.processBlock = function(block, commit, callback) {
     commit = true;
   }
 
-  self.vm.runBlock(
+  vm.runBlock(
     {
       block: block,
       generate: true,
@@ -746,7 +752,7 @@ BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
 
     block.genTxTrie(() => {
       block.header.transactionsTrie = block.txTrie.root;
-      self.processBlock(block, true, callback);
+      self.processBlock(self.vm, block, true, callback);
     });
   });
 };
@@ -759,11 +765,11 @@ BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
  *
  * Strategy:
  *
+ *  1. Clone the VM so running the block doesn't affect state
  *  1. Find block where transaction occurred
  *  2. Set state root of that block
  *  3. Rerun every transaction in that block prior to and including the requested transaction
- *  4. Reset state root back to original
- *  5. Send trace results back.
+ *  4. Send trace results back.
  *
  * @param  {[type]}   tx       [description]
  * @param  {Function} callback [description]
@@ -774,6 +780,9 @@ BlockchainDouble.prototype.processTransactionTrace = function(hash, params, call
   var targetHash = to.hex(hash);
   var txHashCurrentlyProcessing = "";
   var txCurrentlyProcessing = null;
+
+  // #1 - Clone the VM so running the block doesn't affect state
+  var vm = this.createVMFromStateTrie(this.stateTrie.copy());
 
   var storageStack = {
     currentDepth: -1,
@@ -850,23 +859,22 @@ BlockchainDouble.prototype.processTransactionTrace = function(hash, params, call
     txCurrentlyProcessing = tx;
     txHashCurrentlyProcessing = to.hex(tx.hash());
     if (txHashCurrentlyProcessing === targetHash) {
-      self.vm.on("step", stepListener);
+      vm.on("step", stepListener);
     }
   }
 
   // afterTxListener cleans up everything.
   function afterTxListener() {
     if (txHashCurrentlyProcessing === targetHash) {
-      self.vm.removeListener("step", stepListener);
-      self.vm.removeListener("beforeTx", beforeTxListener);
-      self.vm.removeListener("afterTx", afterTxListener);
+      removeListeners();
     }
   }
 
-  // Listen to beforeTx and afterTx so we know when our target transaction
-  // is processing. These events will add the vent listener for getting the trace data.
-  self.vm.on("beforeTx", beforeTxListener);
-  self.vm.on("afterTx", afterTxListener);
+  function removeListeners() {
+    vm.removeListener("step", stepListener);
+    vm.removeListener("beforeTx", beforeTxListener);
+    vm.removeListener("afterTx", afterTxListener);
+  }
 
   // #1 - get block via transaction receipt
   this.getTransactionReceipt(targetHash, function(err, receipt) {
@@ -886,44 +894,49 @@ BlockchainDouble.prototype.processTransactionTrace = function(hash, params, call
         return callback(err);
       }
 
-      var startingStateRoot = self.stateTrie.root;
+      vm.stateManager.getStateRoot((err, startingStateRoot) => {
+        if (err) {
+          return callback(err);
+        }
 
-      // #2 - Set state root of original block
-      self.vm.stateManager._cache.clear();
-      self.vm.stateManager.setStateRoot(parent.header.stateRoot, () => {
-        // Prepare the "next" block with necessary transactions
-        self.createBlock(parent, function(err, block) {
-          if (err) {
-            return callback(err);
-          }
+        // #2 - Set state root of original block
+        vm.stateManager.setStateRoot(parent.header.stateRoot, () => {
+          vm.stateManager._cache.clear();
 
-          for (var i = 0; i < targetBlock.transactions.length; i++) {
-            var tx = targetBlock.transactions[i];
-            block.transactions.push(tx);
-
-            // After including the target transaction, that's all we need to do.
-            if (to.hex(tx.hash()) === targetHash) {
-              break;
-            }
-          }
-
-          // #3 - Process the block without committing the data.
-          self.processBlock(block, false, function(err) {
-            // Ignore runtime errors, or else erroneous transactions can't be traced.
-            if (err && err.message.indexOf("VM Exception") === 0) {
-              err = null;
+          // Prepare the "next" block with necessary transactions
+          self.createBlock(parent, function(err, block) {
+            if (err) {
+              return callback(err);
             }
 
-            // #4 - reset the state root.
-            self.stateTrie.root = startingStateRoot;
+            for (var i = 0; i < targetBlock.transactions.length; i++) {
+              var tx = targetBlock.transactions[i];
+              block.transactions.push(tx);
 
-            // Just to be safe
-            self.vm.removeListener("beforeTx", beforeTxListener);
-            self.vm.removeListener("afterTx", afterTxListener);
-            self.vm.removeListener("step", stepListener);
+              // After including the target transaction, that's all we need to do.
+              if (to.hex(tx.hash()) === targetHash) {
+                break;
+              }
+            }
 
-            // #5 - send state results back
-            callback(err, returnVal);
+            // Listen to beforeTx and afterTx so we know when our target transaction
+            // is processing. These events will add the event listener for getting the trace data.
+            vm.on("beforeTx", beforeTxListener);
+            vm.on("afterTx", afterTxListener);
+
+            // #3 - Process the block without committing the data.
+            self.processBlock(vm, block, false, function(err) {
+              // Ignore runtime errors, or else erroneous transactions can't be traced.
+              if (err && err.message.indexOf("VM Exception") === 0) {
+                err = null;
+              }
+
+              // Just to be safe
+              removeListeners();
+
+              // #4 - send state results back
+              callback(err, returnVal);
+            });
           });
         });
       });

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -765,7 +765,7 @@ BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
  *
  * Strategy:
  *
- *  1. Clone the VM so running the block doesn't affect state
+ *  0. Clone the VM so running the block doesn't affect state
  *  1. Find block where transaction occurred
  *  2. Set state root of that block
  *  3. Rerun every transaction in that block prior to and including the requested transaction
@@ -781,7 +781,7 @@ BlockchainDouble.prototype.processTransactionTrace = function(hash, params, call
   var txHashCurrentlyProcessing = "";
   var txCurrentlyProcessing = null;
 
-  // #1 - Clone the VM so running the block doesn't affect state
+  // #0 - Clone the VM so running the block doesn't affect state
   var vm = this.createVMFromStateTrie(this.stateTrie.copy());
 
   var storageStack = {

--- a/test/debug.js
+++ b/test/debug.js
@@ -138,9 +138,10 @@ describe("Debug", function() {
           resolve();
         }
       );
-    }).then(() => {
+    }).then(async() => {
       // Now let's make sure rerunning this transaction trace didn't change state
-      return debugContract.methods.value().call({ from: accounts[0], gas: 3141592 });
+      const value = await debugContract.methods.value().call({ from: accounts[0], gas: 3141592 });
+      assert.strictEqual(value, expectedValueBeforeTrace);
     });
   });
 });


### PR DESCRIPTION
Also sneaking `self.vm.stateManager._cache.flush(callback);` back in instead of using the flush side effect of `self.vm.stateManager.getStateRoot(callback);`