### PR TITLE
Remove extra test run from coverall support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TODO
 build
 npm-shrinkwrap.json.bak
 test/testdb
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run _lint && npm run _mocha",
     "test-build": "cross-env TEST_BUILD=node npm run _mocha",
     "test-web-experimental": "cross-env TEST_BUILD=web-experimental npm run _mocha",
-    "test-coverage": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
+    "local-coverage": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test": "npm run _lint && npm run _mocha",
     "test-build": "cross-env TEST_BUILD=node npm run _mocha",
     "test-web-experimental": "cross-env TEST_BUILD=web-experimental npm run _mocha",
-    "local-coverage": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
     "lib": "./lib"
   },
   "scripts": {
-    "_mocha": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
+    "_mocha": "mocha --check-leaks --recursive --globals _scratch,sanitizedData",
+    "nyc_mocha": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
     "_lint": "eslint --ignore-path .gitignore .",
     "build": "webpack-cli --config ./webpack/node/core.webpack.config.js",
     "build-web": "webpack-cli --config ./webpack/web-experimental/core.webpack.config.js",
     "format": "prettier --write \"{lib,perf,test}/**/*.js\" && eslint --fix --ignore-path .gitignore .",
     "prepublishOnly": "npm run test && npm run build && npm run test-build && mv npm-shrinkwrap.json npm-shrinkwrap.json.bak && npm prune --only=prod && npm shrinkwrap",
     "postpublish": "rm npm-shrinkwrap.json && mv npm-shrinkwrap.json.bak npm-shrinkwrap.json && npm ci",
-    "test": "npm run _lint && npm run _mocha",
+    "test": "npm run _lint && npm run nyc_mocha",
     "test-build": "cross-env TEST_BUILD=node npm run _mocha",
     "test-web-experimental": "cross-env TEST_BUILD=web-experimental npm run _mocha",
     "coverage": "nyc report --reporter=text-lcov | coveralls"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib": "./lib"
   },
   "scripts": {
-    "_mocha": "mocha --check-leaks --recursive --globals _scratch,sanitizedData",
+    "_mocha": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
     "_lint": "eslint --ignore-path .gitignore .",
     "build": "webpack-cli --config ./webpack/node/core.webpack.config.js",
     "build-web": "webpack-cli --config ./webpack/web-experimental/core.webpack.config.js",
@@ -20,7 +20,7 @@
     "test-build": "cross-env TEST_BUILD=node npm run _mocha",
     "test-web-experimental": "cross-env TEST_BUILD=web-experimental npm run _mocha",
     "test-coverage": "nyc mocha --check-leaks --recursive --globals _scratch,sanitizedData",
-    "coverage": "npm run test-coverage && nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "abstract-leveldown": "3.0.0",


### PR DESCRIPTION
Configured Travis to run `npm test` once and submit the test data to coveralls.io.
Also added local test coverage support.