### PR TITLE
Add guard for undefined connection

### DIFF
--- a/lib/webSocketServer.js
+++ b/lib/webSocketServer.js
@@ -83,9 +83,9 @@ ConnectionManager.prototype._handleRequest = function(connection, payload) {
   switch (payload.method) {
     case "eth_subscribe":
       self.provider.send(payload, function(err, result) {
-        if (!err && result.result) {
-          self.connections[connection.id].subscriptions[result.result] = true;
-          self.connectionsBySubscriptionId[result.result] = self.connections[connection.id];
+        if (!err && result.result && self.connections[connection.id]) {
+            self.connections[connection.id].subscriptions[result.result] = true;
+            self.connectionsBySubscriptionId[result.result] = self.connections[connection.id];
         }
         connection.send(JSON.stringify(result));
       });

--- a/lib/webSocketServer.js
+++ b/lib/webSocketServer.js
@@ -84,8 +84,8 @@ ConnectionManager.prototype._handleRequest = function(connection, payload) {
     case "eth_subscribe":
       self.provider.send(payload, function(err, result) {
         if (!err && result.result && self.connections[connection.id]) {
-            self.connections[connection.id].subscriptions[result.result] = true;
-            self.connectionsBySubscriptionId[result.result] = self.connections[connection.id];
+          self.connections[connection.id].subscriptions[result.result] = true;
+          self.connectionsBySubscriptionId[result.result] = self.connections[connection.id];
         }
         connection.send(JSON.stringify(result));
       });


### PR DESCRIPTION
Sometimes server is crashing while running tests cause self.connections[connection.id] is undefined.

fixes https://github.com/trufflesuite/ganache-cli/issues/633