### PR TITLE
Add notes when creating a server and accesing the provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,8 @@ As a general HTTP and WebSocket server:
 ```javascript
 const ganache = require("ganache-core");
 const server = ganache.server();
-server.listen(port, function(err, blockchain) {...});
-```
-
-### Notes
-
-Do not use `const provider = ganache.provider()` and `const server = ganache.server();` in the same process because it will create two separate blockchains. This is the correct way of accessing the provider when creating a server:
-
-```javascript
-const ganache = require("ganache-core");
-const server = ganache.server();
 const provider = server.provider;
+server.listen(port, function(err, blockchain) {...});
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ const server = ganache.server();
 server.listen(port, function(err, blockchain) {...});
 ```
 
+### Notes
+
+Do not use `const provider = ganache.provider()` and `const server = ganache.server();` in the same process because it will create two separate blockchains. This is the correct way of accessing the provider when creating a server:
+
+```javascript
+const ganache = require("ganache-core");
+const server = ganache.server();
+const provider = server.provider;
+```
+
 ## Options
 
 Both `.provider()` and `.server()` take a single object which allows you to specify behavior of the Ganache instance. This parameter is optional. Available options are:


### PR DESCRIPTION
Using `.server()` and `.provider()` at the same time can lead to unexpected behavior and it's prone to bugs

```js
const ganache = require("ganache-core");
const server = ganache.server();
const provider = ganache.provider(); // parallel "blockchain" 
```

To avoid problems this is the way it should be used:

```js
const ganache = require("ganache-core");
const server = ganache.server();
const provider = server.provider
```