### PR TITLE
replace Web3() by Web3(provider)

### DIFF
--- a/test/bad_input.js
+++ b/test/bad_input.js
@@ -187,15 +187,14 @@ var tests = function(web3) {
 };
 
 describe("Provider:", function() {
-  var web3 = new Web3();
-  web3.setProvider(Ganache.provider({}));
+  let web3 = new Web3(Ganache.provider({}));
   tests(web3);
 });
 
 describe("Server:", function(done) {
-  var web3 = new Web3();
-  var port = 12345;
-  var server;
+  let port = 12345;
+  let web3 = new Web3("http://localhost:" + port);
+  let server;
 
   before("Initialize Ganache server", function(done) {
     server = Ganache.server({});

--- a/test/events.js
+++ b/test/events.js
@@ -293,8 +293,7 @@ var logger = {
 };
 
 describe("Provider:", function() {
-  var web3 = new Web3();
-  web3.setProvider(
+  let web3 = new Web3(
     Ganache.provider({
       logger: logger
     })
@@ -303,9 +302,9 @@ describe("Provider:", function() {
 });
 
 describe("Server:", function(done) {
-  var web3 = new Web3();
-  var port = 12345;
-  var server;
+  let port = 12345;
+  let web3 = new Web3("ws://localhost:" + port);
+  let server;
 
   before("Initialize Ganache server", function(done) {
     server = Ganache.server({

--- a/test/forking.js
+++ b/test/forking.js
@@ -33,12 +33,11 @@ describe("Forking", function() {
 
   var initialFallbackAccountState = {};
 
-  var forkedWeb3 = new Web3();
-  var mainWeb3 = new Web3();
-
   var forkedWeb3NetworkId = Date.now();
   var forkedWeb3Port = 21345;
   var forkedTargetUrl = "ws://localhost:" + forkedWeb3Port;
+  var forkedWeb3 = new Web3(forkedTargetUrl);
+  var mainWeb3 = new Web3("http://localhost:" + forkedWeb3Port);
   var forkBlockNumber;
 
   var initialDeployTransactionHash;

--- a/test/forking_deploy_after_fork.js
+++ b/test/forking_deploy_after_fork.js
@@ -27,8 +27,8 @@ describe("Contract Deployed on Main Chain After Fork", function() {
   var forkedServer;
   var mainAccounts;
 
-  var forkedWeb3 = new Web3();
-  var mainWeb3 = new Web3();
+  var forkedWeb3 = new Web3("ws://localhost:21345");
+  var mainWeb3 = new Web3("http://localhost:21345");
 
   var forkedTargetUrl = "ws://localhost:21345";
 

--- a/test/persistence.js
+++ b/test/persistence.js
@@ -38,7 +38,7 @@ const contract = {
 
 const runTests = function(providerInit) {
   describe("Persistence ", function() {
-    const web3 = new Web3();
+    let web3 = null;
     let accounts;
     let tx;
     let provider;
@@ -46,6 +46,7 @@ const runTests = function(providerInit) {
     before("init provider", function() {
       providerInit(function(p) {
         provider = p;
+        web3 = new Web3(p);
         web3.setProvider(p);
       });
     });
@@ -101,8 +102,8 @@ const runTests = function(providerInit) {
 
 const runRegressionTests = function(regressionProviderInit, memdbProviderInit) {
   describe("Verify previous db compatibility", function() {
-    const web3 = new Web3();
-    const memdbWeb3 = new Web3();
+    let web3 = null;
+    let memdbWeb3 = null;
     const str = JSON.stringify;
     const memdbBlocks = [];
     const blocks = [];
@@ -112,9 +113,11 @@ const runRegressionTests = function(regressionProviderInit, memdbProviderInit) {
 
     before("init provider", function() {
       regressionProviderInit(function(p) {
+        web3 = new Web3(p);
         web3.setProvider(p);
       });
       memdbProviderInit(function(p) {
+        memdbWeb3 = new Web3(p);
         memdbWeb3.setProvider(p);
         memdbSend = generateSend(p);
       });

--- a/test/requests.js
+++ b/test/requests.js
@@ -301,8 +301,7 @@ const tests = function(web3) {
 
     // Load account.
     before(async function() {
-      signingWeb3 = new Web3();
-      signingWeb3.setProvider(
+      signingWeb3 = new Web3(
         Ganache.provider({
           accounts: [acc]
         })
@@ -367,8 +366,7 @@ const tests = function(web3) {
 
     // Load account.
     before(async function() {
-      signingWeb3 = new Web3();
-      signingWeb3.setProvider(
+      signingWeb3 = new Web3(
         Ganache.provider({
           accounts: [acc]
         })
@@ -1560,8 +1558,7 @@ const logger = {
 
 describe("Provider:", function() {
   const Web3 = require("web3");
-  const web3 = new Web3();
-  web3.setProvider(
+  const web3 = new Web3(
     Ganache.provider({
       logger: logger,
       seed: "1337"
@@ -1579,8 +1576,8 @@ describe("Provider:", function() {
 
 describe("HTTP Server:", function() {
   const Web3 = require("web3");
-  const web3 = new Web3();
   const port = 12345;
+  const web3 = new Web3("http://localhost:" + port);
   let server;
 
   before("Initialize Ganache server", async function() {
@@ -1603,8 +1600,8 @@ describe("HTTP Server:", function() {
 
 describe("WebSockets Server:", function() {
   const Web3 = require("web3");
-  const web3 = new Web3();
   const port = 12345;
+  const web3 = new Web3("ws://localhost:" + port);
   let server;
 
   before("Initialize Ganache server", async function() {

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -59,7 +59,7 @@ const testWebSocket = function(web3) {
 
 describe("WebSockets Server:", function() {
   const Web3 = require("web3");
-  const web3 = new Web3();
+  const web3 = new Web3("ws://localhost:" + (PORT + 1));
   let server;
 
   before("Initialize Ganache server", async function() {
@@ -83,7 +83,7 @@ describe("WebSockets Server:", function() {
 
 describe("HTTP Server should not handle subscriptions:", function() {
   const Web3 = require("web3");
-  const web3 = new Web3();
+  const web3 = new Web3(HTTPADDRESS);
   let server;
 
   before("Initialize Ganache server", async function() {


### PR DESCRIPTION
The Web3() syntax is not valid anymore for the web3js project owner. To upgrade web3js to a recent version (> beta 37), it is an operation needed. However, this is not sufficient.

Other changes:
 * Web3.utils.toWei to Web3Utils.toWei (with the package web3-utils)
 * Web3.utils.BN to Web3Utils.BN
 * remove web3-providers-ws and replace by Web3.providers.WebsocketProvider

But after these changes, many unit tests doesn't work anymore