### PR TITLE
Added eth_chainId

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The RPC methods currently implemented are:
 * [eth_accounts](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_accounts)
 * [eth_blockNumber](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_blockNumber)
 * [eth_call](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_call)
+* `eth_chainId`
 * [eth_coinbase](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_coinbase)
 * [eth_estimateGas](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimateGas)
 * [eth_gasPrice](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gasPrice)

--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -145,6 +145,11 @@ GethApiDouble.prototype.eth_blockNumber = function(callback) {
   });
 };
 
+GethApiDouble.prototype.eth_chainId = function(callback) {
+  // chainId of 1337 is the default for private networks as per EIP-155
+  callback(null, to.hex(1337));
+};
+
 GethApiDouble.prototype.eth_coinbase = function(callback) {
   callback(null, this.state.coinbase);
 };

--- a/test/requests.js
+++ b/test/requests.js
@@ -89,6 +89,21 @@ const tests = function(web3) {
     });
   });
 
+  describe("eth_chainId", function() {
+    it("should return a default chain id of a private network", async function() {
+      const send = pify(web3._provider.send.bind(web3._provider));
+
+      const result = await send({
+        id: new Date().getTime(),
+        jsonrpc: "2.0",
+        method: "eth_chainId",
+        params: []
+      });
+
+      assert.strictEqual(result.result, "0x539"); // 0x539 === 1337
+    });
+  });
+
   describe("eth_coinbase", function() {
     it("should return correct address", async function() {
       const coinbase = await web3.eth.getCoinbase();


### PR DESCRIPTION
Fixes trufflesuite#339

Latest betas of web3.js have trouble cooperating with ganache because `eth_chainId` was unsupported. This PR adds support for handling such requests.