### PR TITLE
Gas estimation: make sure we always return a `lowestIndex` for a range

### DIFF
--- a/lib/utils/gasEstimation.js
+++ b/lib/utils/gasEstimation.js
@@ -119,7 +119,7 @@ module.exports = (vm, runArgs, err, callback) => {
    */
   const findLowestIndex = (start, stop) => {
     let lowestGas = Infinity;
-    let lowestIndex;
+    let lowestIndex = stop;
     for (let i = start; i <= stop; i++) {
       if (steps.ops[i].gasLeft <= lowestGas) {
         // Find the new lowest gas index


### PR DESCRIPTION
Even for invalid ranges. Fixes #417 