### PR TITLE
Change transaction signature value encoding to QUANTITY

### DIFF
--- a/lib/utils/transaction.js
+++ b/lib/utils/transaction.js
@@ -300,8 +300,8 @@ module.exports = class Transaction extends EthereumJsTransaction {
       gasPrice: to.rpcQuantityHexString(this.gasPrice),
       input: to.rpcDataHexString(this.data),
       v: to.nullableRpcQuantityHexString(this.v),
-      r: to.nullableRpcDataHexString(this.r),
-      s: to.nullableRpcDataHexString(this.s)
+      r: to.nullableRpcQuantityHexString(this.r),
+      s: to.nullableRpcQuantityHexString(this.s)
     };
 
     return resultJSON;


### PR DESCRIPTION
Even though the Ethereum JSON-RPC spec says that transaction signature
values R and S are DATA, all clients encode them as QUANTITY. The
signature values are defined as numbers in the yellow paper, suggesting
QUANTITY as the correct encoding. This change ensures ganache is compatible
with Geth, Parity and any future spec change.

I found this issue through https://github.com/ethereum/go-ethereum/issues/19461 on
the go-ethereum tracker. See https://gist.github.com/fjl/69454fe6b56d04b3c4932d8673dedc63
for a comprehensive reproducer script.

