### PR TITLE
fix: `evm_revert` crash when passed an invalid `subscriptionId`

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -807,14 +807,21 @@ StateManager.prototype.snapshot = function(callback) {
 };
 
 StateManager.prototype.revert = function(snapshotId, callback) {
-  var self = this;
-
+  if (snapshotId === null || snapshotId === undefined) {
+    callback(new Error("invalid snapshotId"));
+    return;
+  }
   // Convert from hex.
-  snapshotId = utils.bufferToInt(snapshotId);
+  try {
+    snapshotId = utils.bufferToInt(snapshotId);
+  } catch (e) {
+    callback(e);
+    return;
+  }
 
   this.logger.log("Reverting to snapshot #" + snapshotId);
 
-  if (snapshotId > this.snapshots.length) {
+  if (snapshotId > this.snapshots.length || snapshotId <= 0) {
     // the snapshot doesn't exist now, or it has already been reverted
     callback(null, false);
     return false;
@@ -822,7 +829,9 @@ StateManager.prototype.revert = function(snapshotId, callback) {
 
   // Convert to zero based.
   snapshotId = snapshotId - 1;
-  var timeAdjustment = this.snapshots[snapshotId].timeAdjustment;
+  const snapShot = this.snapshots[snapshotId];
+  var timeAdjustment = snapShot.timeAdjustment;
+  var self = this;
 
   // Loop through each snapshot with a higher id than the current one.
   async.whilst(

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -807,6 +807,8 @@ StateManager.prototype.snapshot = function(callback) {
 };
 
 StateManager.prototype.revert = function(snapshotId, callback) {
+  var self = this;
+
   if (snapshotId === null || snapshotId === undefined) {
     callback(new Error("invalid snapshotId"));
     return;
@@ -829,9 +831,7 @@ StateManager.prototype.revert = function(snapshotId, callback) {
 
   // Convert to zero based.
   snapshotId = snapshotId - 1;
-  const snapShot = this.snapshots[snapshotId];
-  var timeAdjustment = snapShot.timeAdjustment;
-  var self = this;
+  var timeAdjustment = this.snapshots[snapshotId].timeAdjustment;
 
   // Loop through each snapshot with a higher id than the current one.
   async.whilst(


### PR DESCRIPTION
Fixes #386