### PR TITLE
fix: make sure we don't call `processNextBlock`'s `callback` twice

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -764,7 +764,9 @@ BlockchainDouble.prototype.processNextBlock = function(timestamp, callback) {
     if (timestamp) {
       self.data.blocks.last(function(err, last) {
         if (err) {
-          return callback(err);
+          // it is safe to ignore this error as we only use the result
+          // to log a warning to the console.
+          return;
         }
         if (last && to.number(last.header.timestamp) > timestamp) {
           self.logger.log(


### PR DESCRIPTION
Fixes #390