### PR TITLE
update eth-sig-util signTypedData call

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -498,7 +498,7 @@ StateManager.prototype.signTypedData = function(address, typedDataToSign) {
     throw new Error("cannot sign data; message missing");
   }
 
-  return sigUtil.signTypedData(account.secretKey, { data: typedDataToSign });
+  return sigUtil.signTypedData_v4(account.secretKey, { data: typedDataToSign });
 };
 
 StateManager.prototype.printTransactionReceipt = function(txHash, error, callback) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4039,9 +4039,9 @@
       }
     },
     "eth-sig-util": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.2.0.tgz",
-      "integrity": "sha512-bAxW35bL4U2lrtjjV8rFGJ8B27z4Sn5v9eIaNdpPUnPfUAtrvx5j8atfyV+k+JOnbppcvKhWCO1rQSBk4kkAhw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.3.0.tgz",
+      "integrity": "sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==",
       "requires": {
         "buffer": "^5.2.1",
         "elliptic": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "clone": "2.1.2",
     "debug": "3.2.6",
     "encoding-down": "5.0.4",
-    "eth-sig-util": "2.2.0",
+    "eth-sig-util": "2.3.0",
     "ethereumjs-abi": "0.6.7",
     "ethereumjs-account": "3.0.0",
     "ethereumjs-block": "2.2.0",

--- a/test/requests.js
+++ b/test/requests.js
@@ -444,6 +444,62 @@ const tests = function(web3) {
       );
     });
 
+    it("should produce a signature whose signer can be recovered (for arrays)", async function() {
+      const typedData = {
+        types: {
+          EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "version", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" }
+          ],
+          Person: [{ name: "name", type: "string" }, { name: "wallets", type: "address[]" }],
+          Mail: [
+            { name: "from", type: "Person" },
+            { name: "to", type: "Person[]" },
+            { name: "contents", type: "string" }
+          ],
+          Group: [{ name: "name", type: "string" }, { name: "members", type: "Person[]" }]
+        },
+        domain: {
+          name: "Ether Mail",
+          version: "1",
+          chainId: 1,
+          verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+        },
+        primaryType: "Mail",
+        message: {
+          from: {
+            name: "Cow",
+            wallets: ["0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826", "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"]
+          },
+          to: [
+            {
+              name: "Bob",
+              wallets: [
+                "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
+                "0xB0B0b0b0b0b0B000000000000000000000000000"
+              ]
+            }
+          ],
+          contents: "Hello, Bob!"
+        }
+      };
+
+      const response = await pify(signingWeb3.currentProvider.send)({
+        jsonrpc: "2.0",
+        method: "eth_signTypedData",
+        params: [accounts[0], typedData],
+        id: new Date().getTime()
+      });
+      assert.strictEqual(
+        response.result,
+        "0x65cbd956f2fae28a601bebc9b906cea0191744bd4c4247bcd27cd08f8eb6b71c" +
+          "78efdf7a31dc9abee78f492292721f362d296cf86b4538e07b51303b67f749061b"
+      );
+    });
+
     after("shutdown", async function() {
       let provider = signingWeb3._provider;
       signingWeb3.setProvider();


### PR DESCRIPTION
updates the `eth_signTypedData` rpc call to use the fully-implemented version of `signTypedData` (now supports array types)

Fixes #459 