### PR TITLE
Updated Receipt's `logIndex`to be  index position in the _block_,. #596

### DIFF
--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -628,7 +628,6 @@ BlockchainDouble.prototype.processBlock = function(vm, block, commit, callback) 
       const rcptTrie = new Trie();
       const promises = [];
       const putInTrie = (trie, key, val) => promisify(trie.put.bind(trie))(key, val);
-
       for (var v = 0; v < results.receipts.length; v++) {
         var result = results.results[v];
         var receipt = results.receipts[v];
@@ -650,7 +649,7 @@ BlockchainDouble.prototype.processBlock = function(vm, block, commit, callback) 
             var data = to.hex(receiptLog[2]);
 
             var log = new Log({
-              logIndex: to.hex(i),
+              logIndex: to.hex(logs.length),
               transactionIndex: to.hex(v),
               transactionHash: txHash,
               block: block,


### PR DESCRIPTION
Updated the log index to be in sync with the number of logs in the block rather than determined by the number of transactions