### PR TITLE
chore: update `ethereumjs-vm` to v4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"account_keys_path"`: `String` - Specifies a file to save accounts and private keys to, for testing.
 * `"vmErrorsOnRPCResponse"`: `boolean` - Whether or not to transmit transaction failures as RPC errors. Set to `false` for error reporting behaviour which is compatible with other clients such as geth and Parity. This is `true` by default to replicate the error reporting behavior of previous versions of ganache.
 * `"hdPath"`: The hierarchical deterministic path to use when generating accounts. Default: "m/44'/60'/0'/0/"
-* `"hardfork"`: `String` Allows to specify which hardfork should be used. Supported hardforks are `byzantium`, `constantinople`, and `petersburg` (default).
+* `"hardfork"`: `String` Allows to specify which hardfork should be used. Supported hardforks are `byzantium`, `constantinople`, `petersburg` (default), and `istanbul` (beta).
 * `"allowUnlimitedContractSize"`: `boolean` - Allows unlimited contract sizes while debugging (NOTE: this setting is often used in conjuction with an increased `gasLimit`). By setting this to `true`, the check within the EVM for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. Setting this to `true` **will** cause `ganache-core` to behave differently than production environments. (default: `false`; **ONLY** set to `true` during debugging).
 * `"gasPrice"`: `String::hex` Sets the default gas price for transactions if not otherwise specified. Must be specified as a `hex` encoded string in `wei`. Defaults to `"0x77359400"` (2 `gwei`).
 * `"gasLimit"`: `String::hex` Sets the block gas limit. Must be specified as a `hex` string. Defaults to `"0x6691b7"`.

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -631,7 +631,7 @@ BlockchainDouble.prototype.processBlock = async function(vm, block, commit, call
     var txLogs = [];
 
     // Only process the transaction's logs if it didn't error.
-    if (result.execResult.exception === 1) {
+    if (result.execResult.exceptionError === undefined) {
       for (var i = 0; i < receipt.logs.length; i++) {
         var receiptLog = receipt.logs[i];
         var address = to.hex(receiptLog[0]);
@@ -1003,7 +1003,7 @@ BlockchainDouble.prototype.processStorageTrace = function(structLog, storageStac
         // this one's more fun, we need to get the value the contract is loading from current storage
         key = to.rpcDataHexString(stack[stack.length - 1], 64).replace("0x", "");
 
-        vm.stateManager.getContractStorage(event.address, "0x" + key, function(err, result) {
+        vm.stateManager.getContractStorage(event.address, Buffer.from(key, "hex"), function(err, result) {
           if (err) {
             return callback(err);
           }

--- a/lib/blockchain_double.js
+++ b/lib/blockchain_double.js
@@ -3,7 +3,7 @@ var Account = require("ethereumjs-account").default;
 var Block = require("ethereumjs-block");
 var Log = require("./utils/log");
 var Receipt = require("./utils/receipt");
-var VM = require("ethereumjs-vm");
+var VM = require("ethereumjs-vm").default;
 var RuntimeError = require("./utils/runtimeerror");
 var Trie = require("merkle-patricia-tree");
 var utils = require("ethereumjs-util");
@@ -527,28 +527,28 @@ BlockchainDouble.prototype.readyCall = function(tx, emulateParent, blockNumber, 
 };
 
 BlockchainDouble.prototype.processCall = function(tx, blockNumber, callback) {
-  this.readyCall(tx, true, blockNumber, (err, vm, runArgs) => {
+  this.readyCall(tx, true, blockNumber, async(err, vm, runArgs) => {
     if (err) {
       callback(err);
       return;
     }
 
-    vm.runTx(runArgs, function(vmerr, result) {
-      // This is a check that has been in there for awhile. I'm unsure if it's required, but it can't hurt.
-      if (vmerr && vmerr instanceof Error === false) {
-        vmerr = new Error("VM error: " + vmerr);
-      }
+    const result = await vm.runTx(runArgs).catch((vmerr) => ({ vmerr }));
+    let vmerr = result.vmerr;
+    // This is a check that has been in there for awhile. I'm unsure if it's required, but it can't hurt.
+    if (vmerr && vmerr instanceof Error === false) {
+      vmerr = new Error("VM error: " + vmerr);
+    }
 
-      // If we're given an error back directly, it's worse than a runtime error. Expose it and get out.
-      if (vmerr) {
-        return callback(vmerr, err);
-      }
+    // If we're given an error back directly, it's worse than a runtime error. Expose it and get out.
+    if (vmerr) {
+      return callback(vmerr, err);
+    }
 
-      // If no error, check for a runtime error. This can return null if no runtime error.
-      vmerr = RuntimeError.fromResults([tx], { results: [result] });
+    // If no error, check for a runtime error. This can return null if no runtime error.
+    vmerr = RuntimeError.fromResults([tx], { results: [result] });
 
-      callback(vmerr, result);
-    });
+    callback(vmerr, result);
   });
 };
 
@@ -575,7 +575,7 @@ BlockchainDouble.prototype.estimateGas = function(tx, blockNumber, callback) {
  * @param  {Function} callback Callback function when transaction processing is completed.
  * @return [type]              [description]
  */
-BlockchainDouble.prototype.processBlock = function(vm, block, commit, callback) {
+BlockchainDouble.prototype.processBlock = async function(vm, block, commit, callback) {
   var self = this;
 
   if (typeof commit === "function") {
@@ -583,120 +583,119 @@ BlockchainDouble.prototype.processBlock = function(vm, block, commit, callback) 
     commit = true;
   }
 
-  vm.runBlock(
-    {
+  const results = await vm
+    .runBlock({
       block: block,
       generate: true,
       skipBlockValidation: true
-    },
-    async function(vmerr, results) {
-      // This is a check that has been in there for awhile. I'm unsure if it's required, but it can't hurt.
-      if (vmerr && vmerr instanceof Error === false) {
-        vmerr = new Error("VM error: " + vmerr);
-      }
+    })
+    .catch((vmerr) => ({ vmerr }));
+  let vmerr = results.vmerr;
+  // This is a check that has been in there for awhile. I'm unsure if it's required, but it can't hurt.
+  if (vmerr && vmerr instanceof Error === false) {
+    vmerr = new Error("VM error: " + vmerr);
+  }
 
-      // If we're given an error back directly, it's worse than a runtime error. Expose it and get out.
-      if (vmerr) {
-        callback(vmerr);
-        return;
-      }
-      // If no error, check for a runtime error. This can return null if no runtime error.
-      vmerr = RuntimeError.fromResults(block.transactions, results);
+  // If we're given an error back directly, it's worse than a runtime error. Expose it and get out.
+  if (vmerr) {
+    callback(vmerr);
+    return;
+  }
+  // If no error, check for a runtime error. This can return null if no runtime error.
+  vmerr = RuntimeError.fromResults(block.transactions, results);
 
-      // Note, even if we have an error, some transactions may still have succeeded.
-      // Process their logs if so, returning the error at the end.
+  // Note, even if we have an error, some transactions may still have succeeded.
+  // Process their logs if so, returning the error at the end.
 
-      var logs = [];
-      var receipts = [];
+  var logs = [];
+  var receipts = [];
 
-      var totalBlockGasUsage = 0;
+  var totalBlockGasUsage = 0;
 
-      results.results.forEach(function(result) {
-        totalBlockGasUsage += to.number(result.gasUsed);
-      });
+  results.results.forEach(function(result) {
+    totalBlockGasUsage += to.number(result.gasUsed);
+  });
 
-      block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
+  block.header.gasUsed = utils.toBuffer(to.hex(totalBlockGasUsage));
 
-      const txTrie = new Trie();
-      const rcptTrie = new Trie();
-      const promises = [];
-      const putInTrie = (trie, key, val) => promisify(trie.put.bind(trie))(key, val);
+  const txTrie = new Trie();
+  const rcptTrie = new Trie();
+  const promises = [];
+  const putInTrie = (trie, key, val) => promisify(trie.put.bind(trie))(key, val);
 
-      for (var v = 0; v < results.receipts.length; v++) {
-        var result = results.results[v];
-        var receipt = results.receipts[v];
-        var tx = block.transactions[v];
-        var txHash = tx.hash();
-        var txLogs = [];
+  for (var v = 0; v < results.receipts.length; v++) {
+    var result = results.results[v];
+    var receipt = results.receipts[v];
+    var tx = block.transactions[v];
+    var txHash = tx.hash();
+    var txLogs = [];
 
-        // Only process the transaction's logs if it didn't error.
-        if (result.vm.exception === 1) {
-          for (var i = 0; i < receipt.logs.length; i++) {
-            var receiptLog = receipt.logs[i];
-            var address = to.hex(receiptLog[0]);
-            var topics = [];
+    // Only process the transaction's logs if it didn't error.
+    if (result.execResult.exception === 1) {
+      for (var i = 0; i < receipt.logs.length; i++) {
+        var receiptLog = receipt.logs[i];
+        var address = to.hex(receiptLog[0]);
+        var topics = [];
 
-            for (var j = 0; j < receiptLog[1].length; j++) {
-              topics.push(to.hex(receiptLog[1][j]));
-            }
-
-            var data = to.hex(receiptLog[2]);
-
-            var log = new Log({
-              logIndex: to.hex(i),
-              transactionIndex: to.hex(v),
-              transactionHash: txHash,
-              block: block,
-              address: address,
-              data: data,
-              topics: topics,
-              type: "mined"
-            });
-
-            logs.push(log);
-            txLogs.push(log);
-          }
+        for (var j = 0; j < receiptLog[1].length; j++) {
+          topics.push(to.hex(receiptLog[1][j]));
         }
 
-        let rcpt = new Receipt(
-          tx,
-          block,
-          txLogs,
-          result.gasUsed.toArrayLike(Buffer),
-          receipt.gasUsed,
-          result.createdAddress,
-          receipt.status,
-          to.hex(receipt.bitvector)
-        );
-        receipts.push(rcpt);
+        var data = to.hex(receiptLog[2]);
 
-        const rawReceipt = [receipt.status, receipt.gasUsed, receipt.bitvector, receipt.logs];
-        const rcptBuffer = utils.rlp.encode(rawReceipt);
-        const key = utils.rlp.encode(v);
-        promises.push(putInTrie(txTrie, key, tx.serialize()));
-        promises.push(putInTrie(rcptTrie, key, rcptBuffer));
-      }
-      await Promise.all(promises);
+        var log = new Log({
+          logIndex: to.hex(i),
+          transactionIndex: to.hex(v),
+          transactionHash: txHash,
+          block: block,
+          address: address,
+          data: data,
+          topics: topics,
+          type: "mined"
+        });
 
-      block.header.transactionsTrie = utils.toBuffer(txTrie.root);
-      block.header.receiptTrie = utils.toBuffer(rcptTrie.root);
-
-      if (commit) {
-        // Put that block on the end of the chain
-        self.putBlock(block, logs, receipts, done);
-      } else {
-        done();
-      }
-
-      function done(e) {
-        if (e) {
-          return callback(e);
-        }
-        // Note we return the vm err here too, if it exists.
-        callback(vmerr, block.transactions, results);
+        logs.push(log);
+        txLogs.push(log);
       }
     }
-  );
+
+    let rcpt = new Receipt(
+      tx,
+      block,
+      txLogs,
+      result.gasUsed.toArrayLike(Buffer),
+      receipt.gasUsed,
+      result.createdAddress,
+      receipt.status,
+      to.hex(receipt.bitvector)
+    );
+    receipts.push(rcpt);
+
+    const rawReceipt = [receipt.status, receipt.gasUsed, receipt.bitvector, receipt.logs];
+    const rcptBuffer = utils.rlp.encode(rawReceipt);
+    const key = utils.rlp.encode(v);
+    promises.push(putInTrie(txTrie, key, tx.serialize()));
+    promises.push(putInTrie(rcptTrie, key, rcptBuffer));
+  }
+  await Promise.all(promises);
+
+  block.header.transactionsTrie = utils.toBuffer(txTrie.root);
+  block.header.receiptTrie = utils.toBuffer(rcptTrie.root);
+
+  if (commit) {
+    // Put that block on the end of the chain
+    self.putBlock(block, logs, receipts, done);
+  } else {
+    done();
+  }
+
+  function done(e) {
+    if (e) {
+      return callback(e);
+    }
+    // Note we return the vm err here too, if it exists.
+    callback(vmerr, block.transactions, results);
+  }
 };
 
 /**

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -641,8 +641,8 @@ StateManager.prototype.processCall = function(from, tx, blockNumber, callback) {
       }
 
       var result = "0x";
-      if (!results.error && results.vm.return) {
-        result = to.hex(results.vm.return);
+      if (!results.error && results.execResult.return) {
+        result = to.hex(results.execResult.return);
       } else if (results.error) {
         self.logger.log(`Error processing call: ${results.error}`);
       }

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -641,8 +641,8 @@ StateManager.prototype.processCall = function(from, tx, blockNumber, callback) {
       }
 
       var result = "0x";
-      if (!results.error && results.execResult.return) {
-        result = to.hex(results.execResult.return);
+      if (!results.error && results.execResult.returnValue) {
+        result = to.hex(results.execResult.returnValue);
       } else if (results.error) {
         self.logger.log(`Error processing call: ${results.error}`);
       }

--- a/lib/utils/gasEstimation.js
+++ b/lib/utils/gasEstimation.js
@@ -1,29 +1,66 @@
 const STIPEND = 2300;
-module.exports = (vm, runArgs, callback) => {
+module.exports = async(vm, runArgs, callback) => {
   const steps = stepTracker();
-
   vm.on("step", steps.collect);
 
-  vm.runTx(runArgs, function(vmerr, result) {
-    if (vmerr) {
-      return callback(vmerr);
-    } else if (result.vm.exception === 0) {
-      const error = result.vm.exceptionError
-        ? new Error(`execution error: ${result.vm.exceptionError.error}`)
-        : new Error("execution error");
-      error.code = -32000;
-      return callback(error);
-    } else if (steps.done()) {
-      let estimate = result.gasUsed;
-      result.gasEstimate = estimate;
-    } else {
-      const actualUsed = steps.ops[0].gasLeft.sub(steps.ops[steps.ops.length - 1].gasLeft).toNumber();
-      const total = getTotal();
-      const sixtyFloorths = total - actualUsed;
-      result.gasEstimate = result.gasUsed.addn(sixtyFloorths);
+  const getTotal = () => {
+    const sysops = steps.systemOps;
+    const ops = steps.ops;
+    const opIndex = (cursor) => sysops[cursor].index;
+    const stack = [];
+    let cursor = 0;
+    let context = Context(0);
+    while (cursor < sysops.length) {
+      const currentIndex = opIndex(cursor);
+      const current = ops[currentIndex];
+      const name = current.opcode.name;
+      if (isCall(name) || isCreate(name)) {
+        if (steps.isSVT(currentIndex)) {
+          context.setStop(currentIndex + 1);
+          context.addRange();
+          context.setStart(currentIndex + 1);
+          context.addSixtyFloorth(STIPEND);
+        } else {
+          context.setStop(currentIndex);
+          context.addRange(current.opcode.fee);
+          stack.push(context);
+          context = Context(currentIndex, current.opcode.fee); // setup next context
+        }
+      } else if (isTerminator(name)) {
+        // only on the last operation
+        context.setStop(currentIndex + 1 < steps.ops.length ? currentIndex + 1 : currentIndex);
+        context.finalizeRange();
+        const ctx = stack.pop();
+        if (ctx) {
+          ctx.transfer(context);
+          context = ctx;
+          context.setStart(currentIndex + 1);
+        } else {
+          break;
+        }
+      } else {
+        throw new Error("INVALID OPCODE");
+      }
+      cursor++;
     }
-    callback(vmerr, result);
-  });
+    let gas = context.getCost();
+    return gas.cost + gas.sixtyFloorths;
+  };
+
+  const result = await vm.runTx(runArgs).catch((vmerr) => ({ vmerr }));
+  const vmerr = result.vmerr;
+  if (vmerr) {
+    return callback(vmerr);
+  } else if (steps.done()) {
+    let estimate = result.gasUsed;
+    result.gasEstimate = estimate;
+  } else {
+    const actualUsed = steps.ops[0].gasLeft.sub(steps.ops[steps.ops.length - 1].gasLeft).toNumber();
+    const total = getTotal();
+    const sixtyFloorths = total - actualUsed;
+    result.gasEstimate = result.gasUsed.addn(sixtyFloorths);
+  }
+  callback(vmerr, result);
 
   const Context = (index, fee) => {
     const base = index === 0;
@@ -89,50 +126,6 @@ module.exports = (vm, runArgs, callback) => {
         }
       }
     };
-  };
-
-  const getTotal = () => {
-    const sysops = steps.systemOps;
-    const ops = steps.ops;
-    const opIndex = (cursor) => sysops[cursor].index;
-    const stack = [];
-    let cursor = 0;
-    let context = Context(0);
-    while (cursor < sysops.length) {
-      const currentIndex = opIndex(cursor);
-      const current = ops[currentIndex];
-      const name = current.opcode.name;
-      if (isCall(name) || isCreate(name)) {
-        if (steps.isSVT(currentIndex)) {
-          context.setStop(currentIndex + 1);
-          context.addRange();
-          context.setStart(currentIndex + 1);
-          context.addSixtyFloorth(STIPEND);
-        } else {
-          context.setStop(currentIndex);
-          context.addRange(current.opcode.fee);
-          stack.push(context);
-          context = Context(currentIndex, current.opcode.fee); // setup next context
-        }
-      } else if (isTerminator(name)) {
-        // only on the last operation
-        context.setStop(currentIndex + 1 < steps.ops.length ? currentIndex + 1 : currentIndex);
-        context.finalizeRange();
-        const ctx = stack.pop();
-        if (ctx) {
-          ctx.transfer(context);
-          context = ctx;
-          context.setStart(currentIndex + 1);
-        } else {
-          break;
-        }
-      } else {
-        throw new Error("INVALID OPCODE");
-      }
-      cursor++;
-    }
-    let gas = context.getCost();
-    return gas.cost + gas.sixtyFloorths;
   };
 };
 

--- a/lib/utils/gasEstimation.js
+++ b/lib/utils/gasEstimation.js
@@ -117,6 +117,12 @@ module.exports = async(vm, runArgs, callback) => {
   const vmerr = result.vmerr;
   if (vmerr) {
     return callback(vmerr);
+  } else if (result.vm.exception === 0) {
+    return callback(
+      result.vm.exceptionError
+        ? new Error(`execution error: ${result.vm.exceptionError.error}`)
+        : new Error("execution error")
+    );
   } else if (steps.done()) {
     let estimate = result.gasUsed;
     result.gasEstimate = estimate;

--- a/lib/utils/gasEstimation.js
+++ b/lib/utils/gasEstimation.js
@@ -3,65 +3,6 @@ module.exports = async(vm, runArgs, callback) => {
   const steps = stepTracker();
   vm.on("step", steps.collect);
 
-  const getTotal = () => {
-    const sysops = steps.systemOps;
-    const ops = steps.ops;
-    const opIndex = (cursor) => sysops[cursor].index;
-    const stack = [];
-    let cursor = 0;
-    let context = Context(0);
-    while (cursor < sysops.length) {
-      const currentIndex = opIndex(cursor);
-      const current = ops[currentIndex];
-      const name = current.opcode.name;
-      if (isCall(name) || isCreate(name)) {
-        if (steps.isSVT(currentIndex)) {
-          context.setStop(currentIndex + 1);
-          context.addRange();
-          context.setStart(currentIndex + 1);
-          context.addSixtyFloorth(STIPEND);
-        } else {
-          context.setStop(currentIndex);
-          context.addRange(current.opcode.fee);
-          stack.push(context);
-          context = Context(currentIndex, current.opcode.fee); // setup next context
-        }
-      } else if (isTerminator(name)) {
-        // only on the last operation
-        context.setStop(currentIndex + 1 < steps.ops.length ? currentIndex + 1 : currentIndex);
-        context.finalizeRange();
-        const ctx = stack.pop();
-        if (ctx) {
-          ctx.transfer(context);
-          context = ctx;
-          context.setStart(currentIndex + 1);
-        } else {
-          break;
-        }
-      } else {
-        throw new Error("INVALID OPCODE");
-      }
-      cursor++;
-    }
-    let gas = context.getCost();
-    return gas.cost + gas.sixtyFloorths;
-  };
-
-  const result = await vm.runTx(runArgs).catch((vmerr) => ({ vmerr }));
-  const vmerr = result.vmerr;
-  if (vmerr) {
-    return callback(vmerr);
-  } else if (steps.done()) {
-    let estimate = result.gasUsed;
-    result.gasEstimate = estimate;
-  } else {
-    const actualUsed = steps.ops[0].gasLeft.sub(steps.ops[steps.ops.length - 1].gasLeft).toNumber();
-    const total = getTotal();
-    const sixtyFloorths = total - actualUsed;
-    result.gasEstimate = result.gasUsed.addn(sixtyFloorths);
-  }
-  callback(vmerr, result);
-
   const Context = (index, fee) => {
     const base = index === 0;
     let start = index;
@@ -127,6 +68,65 @@ module.exports = async(vm, runArgs, callback) => {
       }
     };
   };
+
+  const getTotal = () => {
+    const sysops = steps.systemOps;
+    const ops = steps.ops;
+    const opIndex = (cursor) => sysops[cursor].index;
+    const stack = [];
+    let cursor = 0;
+    let context = Context(0);
+    while (cursor < sysops.length) {
+      const currentIndex = opIndex(cursor);
+      const current = ops[currentIndex];
+      const name = current.opcode.name;
+      if (isCall(name) || isCreate(name)) {
+        if (steps.isSVT(currentIndex)) {
+          context.setStop(currentIndex + 1);
+          context.addRange();
+          context.setStart(currentIndex + 1);
+          context.addSixtyFloorth(STIPEND);
+        } else {
+          context.setStop(currentIndex);
+          context.addRange(current.opcode.fee);
+          stack.push(context);
+          context = Context(currentIndex, current.opcode.fee); // setup next context
+        }
+      } else if (isTerminator(name)) {
+        // only on the last operation
+        context.setStop(currentIndex + 1 < steps.ops.length ? currentIndex + 1 : currentIndex);
+        context.finalizeRange();
+        const ctx = stack.pop();
+        if (ctx) {
+          ctx.transfer(context);
+          context = ctx;
+          context.setStart(currentIndex + 1);
+        } else {
+          break;
+        }
+      } else {
+        throw new Error("INVALID OPCODE");
+      }
+      cursor++;
+    }
+    let gas = context.getCost();
+    return gas.cost + gas.sixtyFloorths;
+  };
+
+  const result = await vm.runTx(runArgs).catch((vmerr) => ({ vmerr }));
+  const vmerr = result.vmerr;
+  if (vmerr) {
+    return callback(vmerr);
+  } else if (steps.done()) {
+    let estimate = result.gasUsed;
+    result.gasEstimate = estimate;
+  } else {
+    const actualUsed = steps.ops[0].gasLeft.sub(steps.ops[steps.ops.length - 1].gasLeft).toNumber();
+    const total = getTotal();
+    const sixtyFloorths = total - actualUsed;
+    result.gasEstimate = result.gasUsed.addn(sixtyFloorths);
+  }
+  callback(vmerr, result);
 };
 
 const check = (arr) => (opname) => arr.includes(opname);

--- a/lib/utils/gasEstimation.js
+++ b/lib/utils/gasEstimation.js
@@ -117,12 +117,8 @@ module.exports = async(vm, runArgs, callback) => {
   const vmerr = result.vmerr;
   if (vmerr) {
     return callback(vmerr);
-  } else if (result.vm.exception === 0) {
-    return callback(
-      result.vm.exceptionError
-        ? new Error(`execution error: ${result.vm.exceptionError.error}`)
-        : new Error("execution error")
-    );
+  } else if (result.execResult.exceptionError) {
+    return callback(new Error(`execution error: ${result.execResult.exceptionError.error}`));
   } else if (steps.done()) {
     let estimate = result.gasUsed;
     result.gasEstimate = estimate;

--- a/lib/utils/runtimeerror.js
+++ b/lib/utils/runtimeerror.js
@@ -38,19 +38,19 @@ RuntimeError.prototype.combine = function(transactions, vmOutput) {
       var result = results[i];
 
       // 1 means no error, oddly.
-      if (result.vm.exception !== 1) {
+      if (result.execResult.exceptionError) {
         var hash = to.hex(tx.hash());
         this.hashes.push(hash);
         var reason;
-        var returnData = result.vm.return;
+        var returnData = result.execResult.return;
         if (returnData && returnData.slice(0, 4).toString("hex") === "08c379a0") {
           reason = abi.rawDecode(["string"], returnData.slice(4))[0];
         }
 
         this.results[hash] = {
-          error: result.vm.exceptionError.error || result.vm.exceptionError,
-          program_counter: result.vm.runState.programCounter,
-          return: to.hex(result.vm.return),
+          error: result.execResult.exceptionError.error || result.execResult.exceptionError,
+          program_counter: result.execResult.runState.programCounter,
+          return: to.hex(result.execResult.return),
           reason: reason
         };
       }

--- a/lib/utils/runtimeerror.js
+++ b/lib/utils/runtimeerror.js
@@ -42,7 +42,7 @@ RuntimeError.prototype.combine = function(transactions, vmOutput) {
         var hash = to.hex(tx.hash());
         this.hashes.push(hash);
         var reason;
-        var returnData = result.execResult.return;
+        var returnData = result.execResult.returnValue;
         if (returnData && returnData.slice(0, 4).toString("hex") === "08c379a0") {
           reason = abi.rawDecode(["string"], returnData.slice(4))[0];
         }
@@ -50,7 +50,7 @@ RuntimeError.prototype.combine = function(transactions, vmOutput) {
         this.results[hash] = {
           error: result.execResult.exceptionError.error || result.execResult.exceptionError,
           program_counter: result.execResult.runState.programCounter,
-          return: to.hex(result.execResult.return),
+          return: to.hex(result.execResult.returnValue),
           reason: reason
         };
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2577,6 +2577,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
+    "core-js-pure": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
+      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4288,36 +4293,22 @@
       }
     },
     "ethereumjs-blockchain": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-3.4.0.tgz",
-      "integrity": "sha512-wxPSmt6EQjhbywkFbftKcb0qRFIZWocHMuDa8/AB4eWL/UPYalNcDyLaxYbrDytmhHid3Uu8G/tA3C/TxZBuOQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-blockchain/-/ethereumjs-blockchain-4.0.1.tgz",
+      "integrity": "sha512-twf2yeyzeBXzCgclLyF9wZEyCKbCweM2KZdZkTsnlqGgaffgnSgY44+z+9BHUIVoWY+gxMj+XsTlTgVcbha8rg==",
       "requires": {
         "async": "^2.6.1",
         "ethashjs": "~0.0.7",
         "ethereumjs-block": "~2.2.0",
         "ethereumjs-common": "^1.1.0",
-        "ethereumjs-util": "~6.0.0",
+        "ethereumjs-util": "~6.1.0",
         "flow-stoplight": "^1.0.0",
         "level-mem": "^3.0.1",
         "lru-cache": "^5.1.1",
-        "safe-buffer": "^5.1.2",
+        "rlp": "^2.2.2",
         "semaphore": "^1.1.0"
       },
       "dependencies": {
-        "ethereumjs-util": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz",
-          "integrity": "sha512-E3yKUyl0Fs95nvTFQZe/ZSNcofhDzUsDlA5y2uoRmf1+Ec7gpGhNCsgKkZBRh7Br5op8mJcYF/jFbmjj909+nQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.6",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4373,48 +4364,34 @@
       }
     },
     "ethereumjs-vm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-3.0.0.tgz",
-      "integrity": "sha512-lNu+G/RWPRCrQM5s24MqgU75PEGiAhL4Ombw0ew6m08d+amsxf/vGAb98yDNdQqqHKV6JbwO/tCGfdqXGI6Cug==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.0.0.tgz",
+      "integrity": "sha512-ALqlz/9PsPF3Tn5XROpLxdx5rECIFb6p3T3h2r9+OnKoEXz8kDjTveYjQXsq/9/oWkVF+D0oGPImuTdgytb7eQ==",
       "requires": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
-        "ethereumjs-account": "^2.0.3",
+        "core-js-pure": "^3.0.1",
+        "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "~2.2.0",
-        "ethereumjs-blockchain": "^3.4.0",
-        "ethereumjs-common": "^1.1.0",
-        "ethereumjs-util": "^6.0.0",
+        "ethereumjs-blockchain": "^4.0.1",
+        "ethereumjs-common": "^1.3.0",
+        "ethereumjs-tx": "^2.1.0",
+        "ethereumjs-util": "^6.1.0",
         "fake-merkle-patricia-tree": "^1.0.1",
         "functional-red-black-tree": "^1.0.1",
         "merkle-patricia-tree": "^2.3.2",
         "rustbn.js": "~0.2.0",
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "^5.1.1",
+        "util.promisify": "^1.0.0"
       },
       "dependencies": {
-        "ethereumjs-account": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
-          "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
+        "ethereumjs-tx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.0.tgz",
+          "integrity": "sha512-q1PFhR5i93OjcoE0G3GGz7XvnpLiddcUSKr28hmMUzVHvvc/+PHmQTx4NrGQUUny7qBq9tEIcvMivdB7uphKtA==",
           "requires": {
-            "ethereumjs-util": "^5.0.0",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          },
-          "dependencies": {
-            "ethereumjs-util": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-              }
-            }
+            "ethereumjs-common": "^1.3.0",
+            "ethereumjs-util": "^6.0.0"
           }
         }
       }
@@ -9182,6 +9159,15 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
     "object.map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -12436,6 +12422,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -582,8 +582,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -1659,7 +1658,6 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -1681,7 +1679,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -1700,7 +1697,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1709,8 +1705,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -1895,7 +1890,6 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -1905,8 +1899,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -1924,8 +1917,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1936,8 +1928,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
       "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1954,8 +1945,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "bytewise": {
       "version": "1.1.0",
@@ -2505,8 +2495,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2541,8 +2530,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -2845,7 +2833,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
-      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -2855,7 +2842,6 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -3104,8 +3090,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "des.js": {
       "version": "1.0.0",
@@ -3121,8 +3106,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -3188,8 +3172,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
@@ -3224,8 +3207,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.237",
@@ -3268,8 +3250,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -3416,8 +3397,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3816,8 +3796,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "eth-block-tracker": {
       "version": "3.0.1",
@@ -4496,7 +4475,6 @@
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -4506,8 +4484,7 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4524,8 +4501,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "events": {
       "version": "3.0.0",
@@ -4877,8 +4853,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -5196,8 +5171,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "from2": {
       "version": "2.3.0",
@@ -5213,8 +5187,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fs-extra": {
       "version": "4.0.3",
@@ -5281,8 +5254,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5300,13 +5272,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5319,18 +5289,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5433,8 +5400,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5444,7 +5410,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5457,20 +5422,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5487,7 +5449,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5560,8 +5521,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5571,7 +5531,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5647,8 +5606,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5678,7 +5636,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5696,7 +5653,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5735,13 +5691,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6220,7 +6174,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -6233,8 +6186,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6242,8 +6194,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
       "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -8032,8 +7983,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lru-cache": {
       "version": "3.2.0",
@@ -8156,8 +8106,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mem": {
       "version": "1.1.0",
@@ -8344,8 +8293,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -8370,8 +8318,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "min-document": {
       "version": "2.19.0",
@@ -8409,7 +8356,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9204,7 +9150,6 @@
       "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
       "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
       "dev": true,
-      "optional": true,
       "requires": {
         "http-https": "^1.0.0"
       }
@@ -9214,7 +9159,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -9449,8 +9393,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -9854,15 +9797,13 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "query-string": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
@@ -9903,22 +9844,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
       "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.2",
@@ -10382,8 +10320,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
       "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "scrypt.js": {
       "version": "0.3.0",
@@ -10472,7 +10409,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -10494,7 +10430,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           },
@@ -10503,8 +10438,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10512,8 +10446,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10591,8 +10524,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -10636,15 +10568,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "simple-get": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-response": "^3.3.0",
         "once": "^1.3.1",
@@ -11183,8 +11113,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -11249,8 +11178,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "string-argv": {
       "version": "0.0.2",
@@ -11567,7 +11495,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -11804,8 +11731,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.11",
@@ -11843,8 +11769,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -11908,8 +11833,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "toposort": {
       "version": "2.0.2",
@@ -11993,7 +11917,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -12212,8 +12135,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "undertaker": {
       "version": "1.2.1",
@@ -12290,8 +12212,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -12384,8 +12305,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
       "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "url-to-options": {
       "version": "1.0.1",
@@ -12403,8 +12323,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "util": {
       "version": "0.10.3",
@@ -12481,8 +12400,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -12595,7 +12513,6 @@
       "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
       "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "web3-core-helpers": "1.2.1",
         "web3-core-method": "1.2.1",
@@ -12608,7 +12525,6 @@
       "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
       "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "underscore": "1.9.1",
         "web3-eth-iban": "1.2.1",
@@ -12620,7 +12536,6 @@
       "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
       "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
@@ -12634,7 +12549,6 @@
       "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
       "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "any-promise": "1.3.0",
         "eventemitter3": "3.1.2"
@@ -12645,7 +12559,6 @@
       "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
       "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
@@ -12659,7 +12572,6 @@
       "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
       "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
@@ -12693,7 +12605,6 @@
       "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
       "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ethers": "4.0.0-beta.3",
         "underscore": "1.9.1",
@@ -12704,15 +12615,13 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
           "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "elliptic": {
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
           "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -12725,7 +12634,6 @@
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
           "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/node": "^10.3.2",
             "aes-js": "3.0.0",
@@ -12744,7 +12652,6 @@
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -12754,22 +12661,19 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
           "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12826,7 +12730,6 @@
       "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
       "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "underscore": "1.9.1",
         "web3-core": "1.2.1",
@@ -12860,7 +12763,6 @@
       "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
       "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "bn.js": "4.11.8",
         "web3-utils": "1.2.1"
@@ -12871,7 +12773,6 @@
       "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
       "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "web3-core": "1.2.1",
         "web3-core-helpers": "1.2.1",
@@ -12885,7 +12786,6 @@
       "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
       "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "web3-core": "1.2.1",
         "web3-core-method": "1.2.1",
@@ -12924,7 +12824,7 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
             "ethereumjs-util": "^5.1.1"
           }
         },
@@ -13070,7 +12970,6 @@
       "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
       "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "web3-core-helpers": "1.2.1",
         "xhr2-cookies": "1.1.0"
@@ -13081,7 +12980,6 @@
       "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
       "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "oboe": "2.1.4",
         "underscore": "1.9.1",
@@ -13093,11 +12991,10 @@
       "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
       "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
-        "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+        "websocket": "github:web3-js/WebSocket-Node#b134a75541b5db59668df81c03e926cd5f325077"
       },
       "dependencies": {
         "debug": {
@@ -13105,7 +13002,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -13114,21 +13010,18 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "nan": {
           "version": "2.14.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
           "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "websocket": {
           "version": "github:web3-js/WebSocket-Node#b134a75541b5db59668df81c03e926cd5f325077",
           "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -13157,7 +13050,6 @@
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
       "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
@@ -13173,7 +13065,6 @@
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
           "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
@@ -13605,7 +13496,6 @@
       "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
       "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer-to-arraybuffer": "^0.0.5",
         "object-assign": "^4.1.1",
@@ -13621,7 +13511,6 @@
       "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
       "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "xhr-request": "^1.0.1"
       }
@@ -13631,7 +13520,6 @@
       "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
       "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "cookiejar": "^2.1.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4364,9 +4364,9 @@
       }
     },
     "ethereumjs-vm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.0.0.tgz",
-      "integrity": "sha512-ALqlz/9PsPF3Tn5XROpLxdx5rECIFb6p3T3h2r9+OnKoEXz8kDjTveYjQXsq/9/oWkVF+D0oGPImuTdgytb7eQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-4.1.0.tgz",
+      "integrity": "sha512-qvgmKkyF+eZ6NvtqTV74z9oRB7UxUStA0gShEbXftovpukVIYVzhvCl9KvUi64Rpo8jufze6Z0zHhiQpZN0Izw==",
       "requires": {
         "async": "^2.1.2",
         "async-eventemitter": "^0.2.2",
@@ -4374,8 +4374,8 @@
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "~2.2.0",
         "ethereumjs-blockchain": "^4.0.1",
-        "ethereumjs-common": "^1.3.0",
-        "ethereumjs-tx": "^2.1.0",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
         "ethereumjs-util": "^6.1.0",
         "fake-merkle-patricia-tree": "^1.0.1",
         "functional-red-black-tree": "^1.0.1",
@@ -4385,12 +4385,17 @@
         "util.promisify": "^1.0.0"
       },
       "dependencies": {
+        "ethereumjs-common": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
+          "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww=="
+        },
         "ethereumjs-tx": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.0.tgz",
-          "integrity": "sha512-q1PFhR5i93OjcoE0G3GGz7XvnpLiddcUSKr28hmMUzVHvvc/+PHmQTx4NrGQUUny7qBq9tEIcvMivdB7uphKtA==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz",
+          "integrity": "sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==",
           "requires": {
-            "ethereumjs-common": "^1.3.0",
+            "ethereumjs-common": "^1.3.1",
             "ethereumjs-util": "^6.0.0"
           }
         }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ethereumjs-block": "2.2.0",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.1.0",
-    "ethereumjs-vm": "4.0.0",
+    "ethereumjs-vm": "4.1.0",
     "heap": "0.2.6",
     "level-sublevel": "6.6.4",
     "levelup": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ethereumjs-block": "2.2.0",
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "6.1.0",
-    "ethereumjs-vm": "3.0.0",
+    "ethereumjs-vm": "4.0.0",
     "heap": "0.2.6",
     "level-sublevel": "6.6.4",
     "levelup": "3.1.1",

--- a/test/contracts/gas/EstimateGas.sol
+++ b/test/contracts/gas/EstimateGas.sol
@@ -103,4 +103,14 @@ contract EstimateGas {
     function currentBlock() public returns (uint) {
         return block.number;
     }
+
+    uint public counter;
+    function runsOutOfGas() public {
+        consumesGas();
+    }
+    function consumesGas() public {
+        for(uint i = 0; i < 100000; i++){
+            counter = i;
+        }
+    }
 }

--- a/test/events.js
+++ b/test/events.js
@@ -250,7 +250,6 @@ var tests = function(web3, EventTest) {
         });
     });
 
-    // TODO: web3 1.0 drops fromBlock on a subscription request - stop skipping this when that is fixed
     it("will not fire if logs are requested when fromBlock doesn't exist", function(done) {
       var event = instance.events.ExampleEvent({ fromBlock: 100000 });
 
@@ -271,7 +270,7 @@ var tests = function(web3, EventTest) {
             done();
           }, 2500);
         });
-    });
+    }).timeout(2750);
   });
 };
 

--- a/test/events.js
+++ b/test/events.js
@@ -268,9 +268,9 @@ var tests = function(web3, EventTest) {
           setTimeout(() => {
             event.removeAllListeners();
             done();
-          }, 2500);
+          }, 250);
         });
-    }).timeout(2750);
+    });
   });
 };
 

--- a/test/events.js
+++ b/test/events.js
@@ -251,7 +251,7 @@ var tests = function(web3, EventTest) {
     });
 
     // TODO: web3 1.0 drops fromBlock on a subscription request - stop skipping this when that is fixed
-    it.skip("will not fire if logs are requested when fromBlock doesn't exist", function(done) {
+    it("will not fire if logs are requested when fromBlock doesn't exist", function(done) {
       var event = instance.events.ExampleEvent({ fromBlock: 100000 });
 
       // fromBlock doesn't exist, hence no logs
@@ -269,7 +269,7 @@ var tests = function(web3, EventTest) {
           setTimeout(() => {
             event.removeAllListeners();
             done();
-          }, 250);
+          }, 2500);
         });
     });
   });

--- a/test/gas/gas.js
+++ b/test/gas/gas.js
@@ -194,7 +194,7 @@ describe("Gas", function() {
                   });
               });
             await Promise.all(promises);
-          });
+          }).timeout(3000);
 
           it("Should estimate gas perfectly with EIP150 - CREATE2", async() => {
             const { accounts, instance, web3 } = Create2;

--- a/test/gas/gas.js
+++ b/test/gas/gas.js
@@ -290,7 +290,7 @@ describe("Gas", function() {
       describe("Refunds", function() {
         it(
           "accounts for Rsclear Refund in gasEstimate when a dirty storage slot is reset and it's original " +
-            " value is 0",
+            "value is 0",
           async function() {
             const { accounts, instance, provider } = context;
             const from = accounts[0];

--- a/test/gas/gas.js
+++ b/test/gas/gas.js
@@ -83,6 +83,15 @@ describe("Gas", function() {
           }
         });
 
+        it("Should not timeout when running a long test", async() => {
+          try {
+            await context.instance.methods.runsOutOfGas().send({ from: context.accounts[0] });
+            assert.fail();
+          } catch (e) {
+            assert(e.message.includes("out of gas"));
+          }
+        }).timeout(5000);
+
         it("Should estimate gas perfectly with EIP150 - recursive CALL", async() => {
           const { accounts, instance, send } = Fib;
           const txParams = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,7 +14,7 @@ declare module "ganache-core" {
       fork_block_number?: string | number;
       gasLimit?: number;
       gasPrice?: string;
-      hardfork?: "byzantium" | "constantinople" | "petersburg";
+      hardfork?: "byzantium" | "constantinople" | "petersburg" | "istanbul";
       hd_path?: string;
       locked?: boolean;
       logger?: {


### PR DESCRIPTION
Once https://github.com/ethereumjs/ethereumjs-vm/pull/578 is pulled in and released this PR will need to updated to point at the new version before being merged in.