### PR TITLE
fix: ensure txs in forked mode can access uncommitted code state

### DIFF
--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -69,7 +69,7 @@ ForkedBlockchain.prototype.patchVM = function(vm) {
   // Unfortunately forking requires a bit of monkey patching, but it gets the job done.
   vm.stateManager._cache._lookupAccount = lookupAccount;
   vm.stateManager._lookupStorageTrie = this.getLookupStorageTrie(trie, lookupAccount);
-  vm.stateManager.getContractCode = this.getCode.bind(this);
+  // vm.stateManager.getContractCode = this.getCode.bind(this);
 };
 
 /**

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -69,7 +69,6 @@ ForkedBlockchain.prototype.patchVM = function(vm) {
   // Unfortunately forking requires a bit of monkey patching, but it gets the job done.
   vm.stateManager._cache._lookupAccount = lookupAccount;
   vm.stateManager._lookupStorageTrie = this.getLookupStorageTrie(trie, lookupAccount);
-  // vm.stateManager.getContractCode = this.getCode.bind(this);
 };
 
 /**

--- a/test/contracts/forking/IntraBlockCache.sol
+++ b/test/contracts/forking/IntraBlockCache.sol
@@ -1,0 +1,19 @@
+pragma solidity >=0.4.21 <0.6.0;
+
+contract Test2 {
+  // Just make sure there really is some code here
+  uint256 foo;
+  function test() external {
+    foo = 1337;
+  }
+}
+
+contract IntraBlockCache {
+  function deploy() external {
+    Test2 x = new Test2();
+    address addr = address(x);
+    uint32 size;
+    assembly { size := extcodesize(addr) }
+    require(size > 0, 'extcodesize is broken');
+  }
+}

--- a/test/forking.js
+++ b/test/forking.js
@@ -552,7 +552,7 @@ describe("Forking", function() {
     });
   });
 
-  describe.only("Intra block state", function() {
+  describe("Intra block state", function() {
     it("should be aware of the vm cache", async() => {
       const { result } = compile("./test/contracts/forking/", "IntraBlockCache");
       const contract = new mainWeb3.eth.Contract(result.contracts["IntraBlockCache.sol"].IntraBlockCache.abi);
@@ -565,8 +565,11 @@ describe("Forking", function() {
           from: accounts[0],
           gas: 190941
         });
-      const receipt = await ibc.methods.deploy().send({ from: accounts[0] });
-      console.log(receipt);
+      return assert.doesNotReject(
+        ibc.methods.deploy().send({ from: accounts[0] }),
+        undefined,
+        "Should reference state in the VM's cache"
+      );
     });
   });
 

--- a/test/forking.js
+++ b/test/forking.js
@@ -552,6 +552,24 @@ describe("Forking", function() {
     });
   });
 
+  describe.only("Intra block state", function() {
+    it("should be aware of the vm cache", async() => {
+      const { result } = compile("./test/contracts/forking/", "IntraBlockCache");
+      const contract = new mainWeb3.eth.Contract(result.contracts["IntraBlockCache.sol"].IntraBlockCache.abi);
+      const accounts = await mainWeb3.eth.getAccounts();
+      const ibc = await contract
+        .deploy({
+          data: result.contracts["IntraBlockCache.sol"].IntraBlockCache.evm.bytecode.object
+        })
+        .send({
+          from: accounts[0],
+          gas: 190941
+        });
+      const receipt = await ibc.methods.deploy().send({ from: accounts[0] });
+      console.log(receipt);
+    });
+  });
+
   after("Shutdown server", (done) => {
     forkedWeb3._provider.connection.close();
     forkedServer.close(function(serverCloseErr) {


### PR DESCRIPTION
Allows the newer VM to reference it's cache.

Resolves #454 