### PR TITLE
[Paired with CLI FIX] Adjust param name

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -54,7 +54,7 @@ function StateManager(options, provider) {
   this.net_version = options.network_id;
   this.mnemonic = options.mnemonic;
   this.wallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(this.mnemonic));
-  this.wallet_hdpath = options.hd_path;
+  this.wallet_hdpath = options.hd_path || options.hdPath;
 
   this.gasPriceVal = to.rpcQuantityHexString(options.gasPrice);
 

--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -54,7 +54,7 @@ function StateManager(options, provider) {
   this.net_version = options.network_id;
   this.mnemonic = options.mnemonic;
   this.wallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(this.mnemonic));
-  this.wallet_hdpath = options.hdPath;
+  this.wallet_hdpath = options.hd_path;
 
   this.gasPriceVal = to.rpcQuantityHexString(options.gasPrice);
 


### PR DESCRIPTION
This fixes a typo between the params and the typings for hd_path.

This pairs with [this pr](https://github.com/trufflesuite/ganache-cli/pull/704) in ganache-cli.