### PR TITLE
fix: windows EPERM due to leaving file descriptor open

### DIFF
--- a/lib/database/filedown.js
+++ b/lib/database/filedown.js
@@ -52,26 +52,46 @@ FileDown.prototype._put = function(key, value, options, callback) {
   // leveldb implementation that doesn't use a separate file for every key Soon(TM).
   accessQueue.execute(lKey, () => {
     // get a tmp file to write the contents to...
-    tmp.file((err, path, fd) => {
+    tmp.file((err, path, fd, cleanupTmpFile) => {
       if (err) {
         callback(err);
         accessQueue.next(lKey);
         return;
       }
 
-      // write the contents to that temp file
+      // write the value to our temporary file
       fs.writeFile(fd, value, "utf8", (err) => {
         if (err) {
+          cleanupTmpFile();
           callback(err);
           accessQueue.next(lKey);
           return;
         }
-        // move the temp file to its final destination
-        fs.rename(path, lKey, (err) => {
-          callback(err);
 
-          // if there is more work to be done on this key, do it.
-          accessQueue.next(lKey);
+        // It worked! Move the temporary file to its final destination
+        fs.rename(path, lKey, (err) => {
+          if (err) {
+            cleanupTmpFile();
+            callback(err);
+            accessQueue.next(lKey);
+            return;
+          }
+
+          // make sure we close this file descriptor now that the file is no
+          // longer "temporary" (because we successfully moved it)
+          fs.close(fd, (err) => {
+            if (err) {
+              // at this point things seem to have worked, but juuuussttt in
+              // case `fs.close` fails, let's log some info so we can try to
+              // debug it
+              console.warn("An unexpected file descriptor close error occured: ", err);
+              cleanupTmpFile();
+            }
+            callback();
+
+            // if there is more work to be done on this key, do it.
+            accessQueue.next(lKey);
+          });
         });
       });
     });


### PR DESCRIPTION
This also fixes a "too many file descriptors open" issue in mac and linux.