### PR TITLE
Add short delay when shutting event test server down

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -310,6 +310,10 @@ describe("Server:", function(done) {
 
   after("Shutdown server", function(done) {
     web3._provider.connection.close();
-    server.close(done);
+
+    // Give web3 a little time to close connection.
+    setTimeout(function() {
+      server.close(done);
+    }, 150);
   });
 });


### PR DESCRIPTION
(Apologies in advance for the length of this explanation)

PR adds a short delay when shutting down the server in `test/event.js`.

**Background**
I'm helping out at Web3.js. One of the project's goals is to improve stability by expanding its test suites. With that in mind, have added `ganache-core`'s unit tests as an E2E which Web3 can sanity check its latest state against.

**Motive**
In a [PR][1] which rewrites the WS provider to support auto-reconnect, am seeing [a failure][2] in a single event test, originating here. 
https://github.com/trufflesuite/ganache-core/blob/9d50099b08e630650e11fe7ccfcf66cf5d9789bf/test/events.js#L63

[1]: https://github.com/ethereum/web3.js/pull/3190
[2]: https://travis-ci.org/ethereum/web3.js/jobs/637843691#L3045-L3049

It's a little mysterious but the TLDR is:
+ The Web3 PR adds logic to trigger an error on unanticipated disconnections
+ `connection.close` is either being run non-sequentially for EventEmitter reasons or failing to complete because interrupted by the server close. 
+ the close event is dirty instead of clean. 

Introducing a short delay before server shutdown allows disconnect to execute as expected. 

By making this change, Web3 will (probably) install without test failures if you upgrade to a forth-coming patch version. 