### PR TITLE
fix: fix db write error on partitioned drives

### DIFF
--- a/lib/database/filedown.js
+++ b/lib/database/filedown.js
@@ -9,6 +9,18 @@ util.inherits(FileDown, AbstractLevelDOWN);
 
 function FileDown(location) {
   this.location = location;
+  const tmpDir = path.join(location, "_tmp");
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true, mode: 0o1777 });
+  } catch (e) {
+    // `recursive` doesn't throw if the file exists, but `recursive` doesn't
+    // exist in Node 8, so we catch the EEXISTS error in that case and ignore it.
+    // once we drop node 8 suport we can remove this try/catch
+    if (e.code !== "EEXIST") {
+      throw e;
+    }
+  }
+  this.tmpOptions = { keep: true, dir: tmpDir };
   AbstractLevelDOWN.call(this, location);
 }
 
@@ -79,7 +91,7 @@ FileDown.prototype._put = function(key, value, options, callback) {
   // leveldb implementation that doesn't use a separate file for every key Soon(TM).
   accessQueue.execute(lKey, () => {
     // get a tmp file to write the contents to...
-    tmp.file({ keep: true }, (err, path, fd, cleanupTmpFile) => {
+    tmp.file(this.tmpOptions, (err, path, fd, cleanupTmpFile) => {
       if (err) {
         callback(err);
         accessQueue.next(lKey);

--- a/lib/database/filedown.js
+++ b/lib/database/filedown.js
@@ -11,6 +11,7 @@ function FileDown(location) {
   this.location = location;
   const tmpDir = path.join(location, "_tmp");
   try {
+    // Fixes https://github.com/trufflesuite/ganache/issues/1617
     fs.mkdirSync(tmpDir, { recursive: true, mode: 0o1777 });
   } catch (e) {
     // `recursive` doesn't throw if the file exists, but `recursive` doesn't


### PR DESCRIPTION
This is an attempt to fix https://github.com/trufflesuite/ganache/issues/1617

If the user's tmp dir and ganache's db directory is not located on the same drive/partition then db file writes fail. This fixes that issue by ensuring the tmp directory is one we control (obviously this means automatic tmp file deletion by the os won't happen in cases where the user has supplied their own db path (like Ganache UI does automatically), but we don't need to worry about that unless ganache crashes, and even then, I don't think it is an issue as only a few key/value files would accumulate there in these exceptional circumstances).

All that said... I haven't yet tested this since it requires some filesystem shenanigans I don't want to set up on a Saturday afternoon.

TODO before merging: actually test that this fixes anything. :-D