### PR TITLE
docs: clarify `accounts` property in options object in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ server.listen(port, function(err, blockchain) { ... });
 
 Both `.provider()` and `.server()` take a single object which allows you to specify behavior of the Ganache instance. This parameter is optional. Available options are:
 
-* `"accounts"`: `Array` of `Object`'s. Each object should have a `balance` key with a hexadecimal value. The key `secretKey` can also be specified, which represents the account's private key. If no `secretKey`, the address is auto-generated with the given balance. If specified, the key is used to determine the account's address.
+* `"accounts"`: `Array` of `Object`'s of the following shape: `{ secretKey: privateKey, balance: HexString }`.
+  * If `secretKey` is specified, the key is used to determine the account's address. Otherwise, the address is auto-generated.
+  * The `balance` is a hexadecimal value of the amount of Ether (in Wei) you want the account to be pre-loaded with.
 * `"debug"`: `boolean` - Output VM opcodes for debugging
 * `"blockTime"`: `number` - Specify blockTime in seconds for automatic mining. If you don't specify this flag, ganache will instantly mine a new block for every transaction. Using the `blockTime` option is discouraged unless you have tests which require a specific mining interval.
 * `"logger"`: `Object` - Object, like `console`, that implements a `log()` function.


### PR DESCRIPTION
Tried to show the shape of the object the API expects.