### PR TITLE
fix: fix for issue #465

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 declare module "ganache-core" {
-  import { Provider as Web3Provider } from "web3/providers";
+  import * as Web3Provider from "web3";
 
   namespace Ganache {
     export interface IProviderOptions {


### PR DESCRIPTION
@davidmurdoch the PR #547 still outputs following error:
`node_modules/ganache-core/typings/index.d.ts(3,12): error TS2305: Module '"web3"' has no exported member 'Provider'.`

The fix was importing as `import * as Web3Provider from "web3";`