### PR TITLE
perf: cache requests to the underlying fork provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Both `.provider()` and `.server()` take a single object which allows you to spec
 * `"total_accounts"`: `number` - Number of accounts to generate at startup.
 * `"fork"`: `string` or `object` - Fork from another currently running Ethereum client at a given block.  When a `string`, input should be the HTTP location and port of the other client, e.g. `http://localhost:8545`. You can optionally specify the block to fork from using an `@` sign: `http://localhost:8545@1599200`. Can also be a `Web3 Provider` object, optionally used in conjunction with the `fork_block_number` option below.
 * `"fork_block_number"`: `string` or `number` - Block number the provider should fork from, when the `fork` option is specified. If the `fork` option is specified as a string including the `@` sign and a block number, the block number in the `fork` parameter takes precedence.
+- `"fork_cache_size"`: `number` - The maximum size of the cache for queries to the forked chain. Defaults to `10000`. You can set this to 0 to disable caching.
 * `"network_id"`: Specify the network id ganache-core will use to identify itself (defaults to the current time or the network id of the forked blockchain if configured)
 * `"time"`: `Date` - Date that the first block should start. Use this feature, along with the `evm_increaseTime` method to test time-dependent code.
 * `"locked"`: `boolean` - whether or not accounts are locked by default.

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -9,6 +9,7 @@ var Web3 = require("web3");
 var to = require("./to.js");
 var Transaction = require("./transaction");
 var async = require("async");
+var LRUCache = require("lru-cache");
 const BN = utils.BN;
 
 var inherits = require("util").inherits;
@@ -56,7 +57,33 @@ function ForkedBlockchain(options) {
   } else {
     this.fork = options.fork;
   }
+
   this.forkBlockNumber = options.fork_block_number;
+  this.forkCacheSize = parseInt(options.fork_cache_size == null ? 10000 : options.fork_cache_size);
+
+  if (this.forkCacheSize !== 0) {
+    const send = this.fork.send;
+    const cache = new LRUCache({ max: this.forkCacheSize });
+
+    // Patch the `send` method of the underlying fork provider. We can
+    // simply cache every non-error result because all requests to the
+    // fork should be deterministic.
+    this.fork.send = (payload, callback) => {
+      const key = JSON.stringify(Object.assign({}, payload, { id: null }));
+
+      if (cache.has(key)) {
+        callback(null, Object.assign({}, JSON.parse(cache.get(key)), { id: payload.id }));
+      } else {
+        send.call(this.fork, payload, (error, result) => {
+          if (!error) {
+            cache.set(key, JSON.stringify(Object.assign({}, result, { id: null })));
+          }
+
+          callback(error, result);
+        });
+      }
+    };
+  }
 
   this.time = options.time;
   this.storageTrieCache = {};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2351,6 +2351,14 @@
           "requires": {
             "xtend": "~4.0.0"
           }
+        },
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "requires": {
+            "pseudomap": "^1.0.1"
+          }
         }
       }
     },
@@ -8650,11 +8658,11 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
-      "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.1"
+        "yallist": "^3.0.2"
       }
     },
     "ltgt": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "level-sublevel": "6.6.4",
     "levelup": "3.1.1",
     "lodash": "4.17.14",
+    "lru-cache": "^5.1.1",
     "merkle-patricia-tree": "2.3.2",
     "seedrandom": "3.0.1",
     "source-map-support": "0.5.12",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,6 +12,7 @@ declare module "ganache-core" {
       default_balance_ether?: number;
       fork?: string | object;
       fork_block_number?: string | number;
+      fork_cache_size?: number;
       gasLimit?: string | number;
       gasPrice?: string;
       hardfork?: "byzantium" | "constantinople" | "petersburg" | "istanbul" | "muirGlacier";


### PR DESCRIPTION
We managed to improve the performance of the ganache fork we use for testing by a factor of 10 to 20 by caching identical requests to the underlying fork (our slowest test used to take ~250 seconds and frequently crash because of exceeding rate limits on our archive node / timeouts - It's now at 13 seconds consistently).

To achieve this, I simply patched the web3 provider used by the fork to intercept all calls to `send` and run them through a LRU cache.