### PR TITLE
Fix forking with configured accounts.

### DIFF
--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -152,11 +152,11 @@ ForkedBlockchain.prototype.initialize = async function(accounts, callback) {
 
     this.forkVersion = forkVersion;
 
-    const forkBlock = await new Promise((resolve, reject) => {
+    const forkBlock = (this.forkBlock = await new Promise((resolve, reject) => {
       this.web3.eth.getBlock(this.forkBlockNumber || "latest", (err, json) => {
         err ? reject(err) : resolve(json);
       });
-    });
+    }));
 
     // If no start time was passed, set the time to where we forked from.
     // We only want to do this if a block was explicitly passed. If a block
@@ -167,6 +167,7 @@ ForkedBlockchain.prototype.initialize = async function(accounts, callback) {
     }
 
     this.forkBlockNumber = this.options.fork_block_number = forkBlock.number;
+    this.forkBlockHash = forkBlock.hash;
 
     // Fetch the nonce for all the accounts before we prime them in our state manager.
     // This is necessary to prevent conflicting contract deployments.
@@ -221,23 +222,17 @@ ForkedBlockchain.prototype.createStateTrie = function(db, root, options) {
 };
 
 ForkedBlockchain.prototype.createGenesisBlock = function(callback) {
-  var self = this;
+  const forkBlock = this.forkBlock;
 
-  self.web3.eth.getBlock(self.forkBlockNumber, function(err, json) {
+  this.createBlock(function(err, block) {
     if (err) {
       return callback(err);
     }
 
-    self.createBlock(function(err, block) {
-      if (err) {
-        return callback(err);
-      }
+    block.header.number = forkBlock.number + 1;
+    block.header.parentHash = forkBlock.hash;
 
-      block.header.number = utils.toBuffer(to.number(json.number) + 1);
-      block.header.parentHash = utils.toBuffer(json.hash);
-
-      callback(null, block);
-    });
+    callback(null, block);
   });
 };
 

--- a/lib/utils/forkedblockchain.js
+++ b/lib/utils/forkedblockchain.js
@@ -72,19 +72,54 @@ function ForkedBlockchain(options) {
   this.web3 = new Web3(this.fork);
 }
 
-ForkedBlockchain.prototype.initialize = function(accounts, callback) {
-  var self = this;
+ForkedBlockchain.prototype.initialize = async function(accounts, callback) {
+  try {
+    const forkVersion = await new Promise((resolve, reject) => {
+      this.web3.eth.net.getId((err, version) => {
+        err ? reject(err) : resolve(version);
+      });
+    });
 
-  this.web3.eth.net.getId(function(err, version) {
-    if (err) {
-      return callback(err);
+    this.forkVersion = forkVersion;
+
+    const forkBlock = await new Promise((resolve, reject) => {
+      this.web3.eth.getBlock(this.forkBlockNumber || "latest", (err, json) => {
+        err ? reject(err) : resolve(json);
+      });
+    });
+
+    // If no start time was passed, set the time to where we forked from.
+    // We only want to do this if a block was explicitly passed. If a block
+    // number wasn't passed, then we're using the last block and the current time.
+    if (!this.time && this.forkBlockNumber) {
+      this.time = this.options.time = new Date(to.number(forkBlock.timestamp) * 1000);
+      this.setTime(this.time);
     }
 
-    self.forkVersion = version;
+    this.forkBlockNumber = this.options.fork_block_number = forkBlock.number;
 
-    BlockchainDouble.prototype.initialize.call(self, accounts, callback);
-  });
+    // Fetch the nonce for all the accounts before we prime them in our state manager.
+    // This is necessary to prevent conflicting contract deployments.
+    const nonces = await Promise.all(
+      accounts.map((account) => {
+        return new Promise((resolve, reject) => {
+          this.web3.eth.getTransactionCount(account.address, this.forkBlockNumber, (err, nonce) => {
+            err ? reject(err) : resolve(nonce);
+          });
+        });
+      })
+    );
+
+    nonces.forEach((nonce, index) => {
+      accounts[index].account.nonce = nonce;
+    });
+
+    BlockchainDouble.prototype.initialize.call(this, accounts, callback);
+  } catch (err) {
+    callback(err);
+  }
 };
+
 ForkedBlockchain.prototype.patchVM = function(vm) {
   const trie = vm.stateManager._trie;
   const lookupAccount = this.getLookupAccount(trie);
@@ -117,26 +152,11 @@ ForkedBlockchain.prototype.createStateTrie = function(db, root, options) {
 
 ForkedBlockchain.prototype.createGenesisBlock = function(callback) {
   var self = this;
-  var blockNumber = this.forkBlockNumber || "latest";
 
-  self.web3.eth.getBlock(blockNumber, function(err, json) {
+  self.web3.eth.getBlock(self.forkBlockNumber, function(err, json) {
     if (err) {
       return callback(err);
     }
-
-    // If no start time was passed, set the time to where we forked from.
-    // We only want to do this if a block was explicitly passed. If a block
-    // number wasn't passed, then we're using the last block and the current time.
-    if (!self.time && self.forkBlockNumber) {
-      self.time = self.options.time = new Date(to.number(json.timestamp) * 1000);
-      self.setTime(self.time);
-    }
-
-    blockNumber = json.number;
-
-    // Update the relevant block numbers
-    self.forkBlockNumber = self.options.fork_block_number = blockNumber;
-    self.stateTrie.forkBlockNumber = self.stateTrie.options.forkBlockNumber = blockNumber;
 
     self.createBlock(function(err, block) {
       if (err) {

--- a/lib/utils/runtimeerror.js
+++ b/lib/utils/runtimeerror.js
@@ -47,10 +47,11 @@ RuntimeError.prototype.combine = function(transactions, vmOutput) {
           reason = abi.rawDecode(["string"], returnData.slice(4))[0];
         }
 
+        const runState = result.execResult.runState;
         this.results[hash] = {
           error: result.execResult.exceptionError.error || result.execResult.exceptionError,
-          program_counter: result.execResult.runState.programCounter,
-          return: to.hex(result.execResult.returnValue),
+          program_counter: runState && runState.programCounter,
+          return: to.hex(returnData),
           reason: reason
         };
       }


### PR DESCRIPTION
Fixes conflicting contract deployments by inheriting the nonces of the configured accounts from the underlying fork.

This error emerges for instance when forking from a previous fork and then attempting to use the same configured accounts to send transactions / deploy contracts. As configured accounts are primed with a nonce of `0` by default, any of these accounts that already deployed contracts on the "previous" fork will now run into contract address collisions when attempting to re-deploy.

This pull request fixes this problem by looking up the nonces of the configured accounts from the previous fork when initializing the new fork.