### PR TITLE
fix: update prepublishOnly script to remove husky from shrinkwrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "webpack-cli --config ./webpack/node/core.webpack.config.js",
     "build-web": "webpack-cli --config ./webpack/web-experimental/core.webpack.config.js",
     "format": "prettier --write \"{lib,perf,test}/**/*.js\" && eslint --fix --ignore-path .gitignore .",
-    "prepublishOnly": "npm run test && npm run build && npm run test-build && cp npm-shrinkwrap.json npm-shrinkwrap.json.bak && rm -rf node_modules/web3-providers-ws/node_modules/websocket/.git && npm prune --only=prod",
+    "prepublishOnly": "npm run test && npm run build && npm run test-build && cp npm-shrinkwrap.json npm-shrinkwrap.json.bak && rm -rf node_modules/web3-providers-ws/node_modules/websocket/.git && npm prune --production && npm shrinkwrap",
     "postpublish": "rm npm-shrinkwrap.json && mv npm-shrinkwrap.json.bak npm-shrinkwrap.json && npm ci",
     "test": "npm run _lint && npm run nyc_mocha",
     "test-build": "cross-env TEST_BUILD=node npm run _mocha",


### PR DESCRIPTION
Hey @davidmurdoch,

I took a look at #562, and fixed it.

This PR modifies the `prepublishOnly` script so that `devDependencies` aren't included in the shrinkwrap file, and hence, not installed be packages depending on `ganache-core`.

The problem was twofold:

1. `npm prune` takes a `--production` flag instead of `--only=prod`. It's very unfortunate that `npm` just silently accepts unused params. You can learn more about this here: https://docs.npmjs.com/cli-commands/prune.html

2. `npm prune` only uninstall dependencies, but doesn't update the shrinkwrap file, so it has to be done manually after running `prune`.

