### PR TITLE
fix: properly cast the date in `evm_setTime`

### DIFF
--- a/lib/subproviders/geth_api_double.js
+++ b/lib/subproviders/geth_api_double.js
@@ -546,7 +546,7 @@ GethApiDouble.prototype.evm_increaseTime = function(seconds, callback) {
 };
 
 GethApiDouble.prototype.evm_setTime = function(date, callback) {
-  callback(null, this.state.blockchain.setTime(date));
+  callback(null, this.state.blockchain.setTime(new Date(date)));
 };
 
 GethApiDouble.prototype.evm_mine = function(timestamp, callback) {


### PR DESCRIPTION
Fixes #600 

When calling `evm_setTime` through JSONRPC, this value is a string/number but `blockchain.setTime` expects it to be a date.

This cannot possibly have side effects since even if a Date is passed in there, `new Date(date)` will preserve the value 