### PR TITLE
chore: move forking tests to a separate directory

### DIFF
--- a/test/forking/deployAfterFork.js
+++ b/test/forking/deployAfterFork.js
@@ -2,9 +2,9 @@ var Web3 = require("web3");
 var Web3WsProvider = require("web3-providers-ws");
 var assert = require("assert");
 var Ganache = require(process.env.TEST_BUILD
-  ? "../build/ganache.core." + process.env.TEST_BUILD + ".js"
-  : "../index.js");
-const compile = require("./helpers/contract/singleFileCompile");
+  ? "../../build/ganache.core." + process.env.TEST_BUILD + ".js"
+  : "../../index.js");
+const compile = require("../helpers/contract/singleFileCompile");
 var logger = {
   log: function(msg) {
     /* console.log(msg) */

--- a/test/forking/forking.js
+++ b/test/forking/forking.js
@@ -1,14 +1,14 @@
-const Transaction = require("../lib/utils/transaction");
+const Transaction = require("../../lib/utils/transaction");
 var Web3 = require("web3");
 var Web3WsProvider = require("web3-providers-ws");
 var assert = require("assert");
 var Ganache = require(process.env.TEST_BUILD
-  ? "../build/ganache.core." + process.env.TEST_BUILD + ".js"
-  : "../index.js");
+  ? "../../build/ganache.core." + process.env.TEST_BUILD + ".js"
+  : "../../index.js");
 
-const compile = require("./helpers/contract/singleFileCompile");
-var to = require("../lib/utils/to.js");
-var generateSend = require("./helpers/utils/rpc");
+const compile = require("../helpers/contract/singleFileCompile");
+var to = require("../../lib/utils/to.js");
+var generateSend = require("../helpers/utils/rpc");
 
 var logger = {
   log: function(msg) {

--- a/test/forking/forkingAsProvider.js
+++ b/test/forking/forkingAsProvider.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
-const bootstrap = require("./helpers/contract/bootstrap");
-const intializeTestProvider = require("./helpers/web3/initializeTestProvider");
+const bootstrap = require("../helpers/contract/bootstrap");
+const intializeTestProvider = require("../helpers/web3/initializeTestProvider");
 
 /**
  * NOTE: Naming in these tests is a bit confusing. Here, the "main chain"


### PR DESCRIPTION
This PR organized the forking tests under a subdirectory in preparation of adding more tests for other forking issues