### PR TITLE
fix(forking): invalidate `_deleted` in `ForkedStorageTrie` if a subsequent `put` happens

### DIFF
--- a/lib/forking/forked_storage_trie.js
+++ b/lib/forking/forked_storage_trie.js
@@ -97,6 +97,23 @@ ForkedStorageBaseTrie.prototype.keyExists = function(key, callback) {
   });
 };
 
+const originalPut = ForkedStorageBaseTrie.prototype.put;
+ForkedStorageBaseTrie.prototype.put = function(key, value, callback) {
+  let rpcKey = to.rpcDataHexString(key);
+  if (this.address) {
+    rpcKey = `${to.rpcDataHexString(this.address)};${rpcKey}`;
+  }
+  this._deleted.get(rpcKey, (_, result) => {
+    if (result === 1) {
+      this._deleted.put(rpcKey, 0, () => {
+        originalPut.call(this, key, value, callback);
+      });
+    } else {
+      originalPut.call(this, key, value, callback);
+    }
+  });
+};
+
 ForkedStorageBaseTrie.prototype.keyIsDeleted = function(key, callback) {
   let rpcKey = to.rpcDataHexString(key);
   if (this.address) {

--- a/test/contracts/forking/StorageDelete.sol
+++ b/test/contracts/forking/StorageDelete.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.6.0;
+
+contract StorageDelete {
+  bool entered;
+
+  constructor() public {
+    entered = true;
+  }
+
+  function test() public nonReentrant {}
+
+  modifier nonReentrant() {
+    require(entered, "re-entered");
+    entered = false;
+    _;
+    entered = true;
+  }
+}

--- a/test/forking/delete.js
+++ b/test/forking/delete.js
@@ -1,0 +1,54 @@
+const assert = require("assert");
+const bootstrap = require("../helpers/contract/bootstrap");
+const intializeTestProvider = require("../helpers/web3/initializeTestProvider");
+
+/**
+ * NOTE: Naming in these tests is a bit confusing. Here, the "main chain"
+ * is the main chain the tests interact with; and the "forked chain" is the
+ * chain that _was forked_. This is in contrast to general naming, where the
+ * main chain represents the main chain to be forked (like the Ethereum live
+ * network) and the fork chaing being "the fork".
+ */
+
+describe("Forking Deletion", () => {
+  let forkedContext;
+  let mainContext;
+  const logger = {
+    log: function(msg) {}
+  };
+
+  before("Set up forked provider with web3 instance and deploy a contract", async function() {
+    this.timeout(5000);
+
+    const contractRef = {
+      contractFiles: ["StorageDelete"],
+      contractSubdirectory: "forking"
+    };
+
+    const ganacheProviderOptions = {
+      logger,
+      seed: "main provider"
+    };
+
+    forkedContext = await bootstrap(contractRef, ganacheProviderOptions);
+  });
+
+  before("Set up main provider and web3 instance", async function() {
+    const { provider: forkedProvider } = forkedContext;
+    mainContext = await intializeTestProvider({
+      fork: forkedProvider,
+      logger,
+      seed: "forked provider"
+    });
+  });
+
+  it("successfully manages storage slot deletion", async() => {
+    const { instance: forkedInstance, abi } = forkedContext;
+    const { web3: mainWeb3 } = mainContext;
+
+    const instance = new mainWeb3.eth.Contract(abi, forkedInstance._address);
+
+    assert.ok(await instance.methods.test().call());
+    assert.ok(await instance.methods.test().call());
+  });
+});


### PR DESCRIPTION
This PR resolves #571 by wrapping the `Trie.put` method in `ForkedStorageTrie`, checking if `_deleted.get(rpcKey) === 1`, and setting it to `0` if it is. This PR adds a simple test that gets to the root of the issue: `_deleted` was being set for a storage slot 0 when a bool was changed from `true` to `false`, but we never "undelete" it if it's set back to `true`. This caused an erroneous error when contracts looked at that boolean again and got `0` because `ForkedStorageTrie` determined it was set to `0` (interpreted as `false`) [here](https://github.com/trufflesuite/ganache-core/blob/34504feaa59d7e59fcc360c0332df10f57131b51/lib/forking/forked_storage_trie.js#L55-L59)

To add a reason for supporting merging #610, those Infura tests gave me a simple, ready to use way to reproduce the error and understand the root cause. From there, I determined I could create a non-Infura reproduction of the error.