### PR TITLE
test: throw if test contracts fail compilation

### DIFF
--- a/test/helpers/contract/compileAndDeploy.js
+++ b/test/helpers/contract/compileAndDeploy.js
@@ -33,6 +33,11 @@ function compile(mainContractName, contractFileNames = [], contractSubdirectory,
 
   const result = JSON.parse(solc.compile(JSON.stringify(input)));
 
+  if (result.errors) {
+    const errorMessages = result.errors.map((error) => error.formattedMessage);
+    throw new Error(`Could not compile test contracts:\n${errorMessages.join("")}`);
+  }
+
   const _mainContractName = mainContractName.endsWith(".sol")
     ? mainContractName.replace(/\.sol$/i, "")
     : mainContractName;

--- a/test/helpers/contract/compileAndDeploy.js
+++ b/test/helpers/contract/compileAndDeploy.js
@@ -33,7 +33,7 @@ function compile(mainContractName, contractFileNames = [], contractSubdirectory,
 
   const result = JSON.parse(solc.compile(JSON.stringify(input)));
 
-  if (result.errors) {
+  if (result.errors && result.errors.some((error) => error.severity === "error")) {
     const errorMessages = result.errors.map((error) => error.formattedMessage);
     throw new Error(`Could not compile test contracts:\n${errorMessages.join("")}`);
   }


### PR DESCRIPTION
This a simple improvement that will throw if the test contracts fail compilation. Otherwise, the error gets squashed and you'll get some other "<ContractName> of undefined" error at line 44 when you try to read `result.contracts`.