### PR TITLE
feat: add ability to use blockHash with eth_getLogs

### DIFF
--- a/lib/statemanager.js
+++ b/lib/statemanager.js
@@ -779,7 +779,8 @@ StateManager.prototype.getLogs = function(filter, callback) {
     {
       fromBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, filter.fromBlock || "latest"),
       toBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, filter.toBlock || "latest"),
-      latestBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, "latest")
+      latestBlock: this.blockchain.getEffectiveBlockNumber.bind(this.blockchain, "latest"),
+      block: this.blockchain.getBlock.bind(this.blockchain, filter.blockHash || 0)
     },
     function(err, results) {
       if (err) {
@@ -788,9 +789,15 @@ StateManager.prototype.getLogs = function(filter, callback) {
       var fromBlock = results.fromBlock;
       var toBlock = results.toBlock;
       var latestBlock = results.latestBlock;
+      var block = results.block;
 
       if (toBlock > latestBlock) {
         toBlock = latestBlock;
+      }
+
+      if (filter.blockHash) {
+        fromBlock = to.number(block.header.number);
+        toBlock = to.number(block.header.number);
       }
 
       var logs = [];

--- a/test/local/events.js
+++ b/test/local/events.js
@@ -179,6 +179,58 @@ var tests = function(web3, EventTest) {
       );
     });
 
+    // NOTE! This test relies on the events triggered in the tests above.
+    it("should return logs using blockHash", function(done) {
+      var provider = web3.currentProvider;
+
+      provider.send(
+        {
+          jsonrpc: "2.0",
+          method: "eth_getBlockByNumber",
+          params: [
+            "latest",
+            false
+          ],
+          id: new Date().getTime()
+        },
+        function(err, result) {
+          if (err) {
+            return done(err);
+          }
+
+          const hash = result.result.hash;
+
+          provider.send(
+            {
+              jsonrpc: "2.0",
+              method: "eth_getLogs",
+              params: [
+                {
+                  blockHash: hash,
+                  topics: [
+                    "0xc54307031d9aa93e0568c363be84a9400dce343fef6a2851d55662a6af1a29da",
+                    "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "0x0000000000000000000000000000000000000000000000000000000000000006"
+                  ]
+                }
+              ],
+              id: new Date().getTime()
+            },
+            function(err, result) {
+              if (err) {
+                return done(err);
+              }
+              const logIndex = result.result[0].logIndex;
+              const transactionIndex = result.result[0].transactionIndex;
+              assert.strictEqual(logIndex, "0x0");
+              assert.strictEqual(transactionIndex, "0x0");
+              done();
+            }
+          );
+        }
+      );
+    });
+
     it("always returns a change for every new block subscription when instamining", function(done) {
       var provider = web3.currentProvider;
 


### PR DESCRIPTION
Implements the ability to use `blockHash` with `eth_getLogs`. This closes https://github.com/trufflesuite/ganache-core/issues/136

See [EIP 234](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-234.md) 

Fix of https://github.com/trufflesuite/ganache-core/pull/635 (sorry about that, extra commit sneaked in when merging between multiple repos)