### PR TITLE
Ensure proper usage of yargs + npm `create` script without using `--`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,19 @@ Runs all tests:
 
 - `npm test` (or the shorthand, `npm t`)
 
+## To create a new chain/flavor
+
+- `npm run create <name> chains`
+
+This will create a new folder at `src/chains/<name>` where `<name>` should be the flavor name (e.g. `ethereum`), which you then can [create packages under](#to-create-a-new-package).
+
 ## To create a new package
 
-- `npm run create <name> --location <location> [--folder <folder>]`
+- `npm run create <name> <location> [<folder>]`
 
 This will create a new package with Ganache defaults at `src/<location>/<name>`.
 
-If you provide the optional `--folder` option, the package will be created at `src/<location>/<folder>`.
+If you provide the optional `<folder>` option, the package will be created at `src/<location>/<folder>`.
 
 ## To add a module to a package:
 

--- a/scripts/create.ts
+++ b/scripts/create.ts
@@ -31,28 +31,29 @@ const chainLocations = getDirectories(join(__dirname, "../src/chains")).map(
 locations = locations.concat(chainLocations);
 const argv = yargs
   .command(
-    `$0 <name> --location [--folder]`,
+    `$0 <name> <location> [<folder>]`,
     `Create a new package in the given location with the provided name.`,
     yargs => {
       return yargs
         .usage(
           chalk`{hex("#e4a663").bold Create a new package in the given {dim <}location{dim >} with the provided {dim <}name{dim >}.}\n\n` +
-            chalk`{bold Usage}\n  {bold $} {dim <}name{dim >} {dim --}location {dim <}location{dim >} {dim [--folder <folder>]}`
+            chalk`{bold Usage}\n  {bold $} {dim <}name{dim >} {dim <}location{dim >} {dim [<folder>]}`
         )
         .positional("name", {
-          describe: `          The name for the new package.`,
+          describe: `The name for the new package.`,
           type: "string",
           demandOption: true
         })
-        .option("location", {
-          alias: "l",
+        .positional("location", {
           describe: `The location for the new package.`,
+          type: "string",
           choices: locations,
           demandOption: true
         })
-        .option("folder", {
-          alias: "f",
-          describe: chalk`Optional override for the folder name for the package instead of using {dim <}name{dim >}.`
+        .positional("folder", {
+          describe: chalk`Optional override for the folder name for the package instead of using {dim <}name{dim >}.`,
+          type: "string",
+          demandOption: false
         });
     }
   )


### PR DESCRIPTION
This PR is part of #700

There was a reason for me adding the `--` requirement and your changes (reflected in #703) just steamrolled over those necessary changes without discussion. I am providing you 2 different options that I strongly encourage you picking and merging one. I also would appreciate PR reviews rather than just coding over what you want/don't want; that way we can have a discussion when you have a disagreement so I can explain why I made the decisions I did.

**This PR is option 1 (without using `--`, but using positional args)**

--

If you don't want to use the `--` that NPM requires you to use to pass `--flag` arguments (what yargs calls "options"), then you need to change the `create` script to use strictly positional arguments.

This is because without the `--`, NPM parses your `--location` and `--folder` as NPM flags instead of `create.ts` flags. It tries to parse, determines they do nothing, ignores them, and proceeds to pass in the other arguments.

![image](https://user-images.githubusercontent.com/549323/104108499-0519d980-527a-11eb-955b-2ceff97476d2.png)

See the top red circle where `--folder` and `--location` are actually dropped. Then further you can see how `location` actually parsed `iamfolder` due to guessing it's position from the command string