### PR TITLE
Ensure proper usage of yargs + npm `create` script with using `--`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,19 @@ Runs all tests:
 
 - `npm test` (or the shorthand, `npm t`)
 
+## To create a new chain/flavor
+
+- `npm run create -- <name> --location chains`
+
+**NOTE:** The `--` between `npm run create` and `<name>` is required to properly use this script.
+
+This will create a new folder at `src/chains/<name>` where `<name>` should be the flavor name (e.g. `ethereum`), which you then can [create packages under](#to-create-a-new-package).
+
 ## To create a new package
 
-- `npm run create <name> --location <location> [--folder <folder>]`
+- `npm run create -- <name> --location <location> [--folder <folder>]`
+
+**NOTE:** The `--` between `npm run create` and `<name>` is required to properly use this script.
 
 This will create a new package with Ganache defaults at `src/<location>/<name>`.
 

--- a/scripts/create.ts
+++ b/scripts/create.ts
@@ -31,7 +31,7 @@ const chainLocations = getDirectories(join(__dirname, "../src/chains")).map(
 locations = locations.concat(chainLocations);
 const argv = yargs
   .command(
-    `$0 <name> --location [--folder]`,
+    `$0 <name> [options]`,
     `Create a new package in the given location with the provided name.`,
     yargs => {
       return yargs
@@ -40,19 +40,22 @@ const argv = yargs
             chalk`{bold Usage}\n  {bold $} {dim <}name{dim >} {dim --}location {dim <}location{dim >} {dim [--folder <folder>]}`
         )
         .positional("name", {
-          describe: `          The name for the new package.`,
+          describe: `The name for the new package.`,
           type: "string",
           demandOption: true
         })
         .option("location", {
           alias: "l",
           describe: `The location for the new package.`,
+          type: "string",
           choices: locations,
           demandOption: true
         })
         .option("folder", {
           alias: "f",
-          describe: chalk`Optional override for the folder name for the package instead of using {dim <}name{dim >}.`
+          describe: chalk`Optional override for the folder name for the package instead of using {dim <}name{dim >}.`,
+          type: "string",
+          demandOption: false
         });
     }
   )
@@ -60,8 +63,6 @@ const argv = yargs
   .version(false)
   .help(false)
   .updateStrings({
-    "Positionals:": chalk.bold("Options"),
-    "Options:": ` `,
     "Not enough non-option arguments: got %s, need at least %s": {
       one: chalk`{red {bold ERROR! Not enough non-option arguments:}\n  got %s, need at least %s}`,
       other: chalk`{red {bold ERROR! Not enough non-option arguments:}\n  got %s, need at least %s}`


### PR DESCRIPTION
This PR is part of #700

See more details of why this PR is necessary in #704

**This PR is option 2 (using named, non-positional args, but requiring `--`**

--

Because of the reasons stated in #704, if you want to use non-positional/named arguments in an NPM script, you must use the `--` between the `npm run <script>` and the first flag.

This PR essentially re-introduces the changes I originally had in #701
